### PR TITLE
feat: NF4 block-swap loading for instruct model and resolution control for ImageEdit

### DIFF
--- a/hunyuan_block_swap.py
+++ b/hunyuan_block_swap.py
@@ -776,40 +776,64 @@ class BlockSwapManager:
     # Block movement
     # ------------------------------------------------------------------
     
-    def _move_block_to_device_raw(
+    def _move_nf4_block_to_device(
         self,
         block_idx: int,
         device: torch.device,
-        non_blocking: bool = None,
     ) -> float:
-        """Move a block using standard block.to() - no buffer store.
-        
-        Used during initial placement (before buffer store exists) and as
-        fallback when a block has no buffer store entry.
+        """Move an NF4 block by iterating Params4bit individually.
+
+        Params4bit.to(device, non_blocking=True) raises cudaErrorInvalidValue
+        when moving CUDA→CPU.  We work around this by moving each parameter
+        with non_blocking=False and explicitly handling quant_state tensors.
+
+        This is slower than block.to() but is the only safe way for NF4.
         """
-        if block_idx >= len(self.blocks):
-            return 0.0
-        
         block = self.blocks[block_idx]
         current_device = self.block_locations.get(block_idx)
         if current_device == device:
             return 0.0
-        
-        if non_blocking is None:
-            non_blocking = self.config.use_non_blocking
-        
+
         start_time = time.time()
-        
-        block.to(device, non_blocking=non_blocking)
-        self._fix_int8_state_devices(block, device)
-        
-        if not non_blocking and device.type == "cuda":
+
+        try:
+            from bitsandbytes.nn import Params4bit
+        except ImportError:
+            Params4bit = None
+
+        for param in block.parameters():
+            if Params4bit is not None and isinstance(param, Params4bit):
+                # Params4bit stores quantized data in .data and metadata in
+                # .quant_state (QuantState object with absmax, code, offset).
+                # We must move both; quant_state.to() handles its internals.
+                if param.data.device != device:
+                    param.data = param.data.to(device)
+                if hasattr(param, 'quant_state') and param.quant_state is not None:
+                    qs = param.quant_state
+                    if hasattr(qs, 'to'):
+                        qs.to(device)
+                    else:
+                        # QuantState may store tensors as plain attributes
+                        for attr_name in ('absmax', 'code', 'offset', 'state2', 'blocksize', 'dtype'):
+                            attr_val = getattr(qs, attr_name, None)
+                            if attr_val is not None and hasattr(attr_val, 'to') and getattr(attr_val, 'device', None) != device:
+                                setattr(qs, attr_name, attr_val.to(device))
+            else:
+                if param.device != device:
+                    param.data = param.data.to(device)
+
+        # Also move any plain buffers
+        for buf in block.buffers():
+            if buf.device != device:
+                buf.data = buf.data.to(device)
+
+        if device.type == "cuda":
             torch.cuda.synchronize(device)
-        
+
         elapsed = time.time() - start_time
         self.block_locations[block_idx] = device
         self.stats.total_swap_time_seconds += elapsed
-        
+
         if device == self.target_device:
             self.stats.total_swaps_to_gpu += 1
             self.stats.blocks_currently_on_gpu += 1
@@ -818,10 +842,61 @@ class BlockSwapManager:
             self.stats.total_swaps_to_cpu += 1
             self.stats.blocks_currently_on_gpu -= 1
             self.stats.blocks_currently_on_cpu += 1
-        
+
+        return elapsed
+
+    def _move_block_to_device_raw(
+        self,
+        block_idx: int,
+        device: torch.device,
+        non_blocking: bool = None,
+    ) -> float:
+        """Move a block using standard block.to() - no buffer store.
+
+        Used during initial placement (before buffer store exists) and as
+        fallback when a block has no buffer store entry.
+        """
+        if block_idx >= len(self.blocks):
+            return 0.0
+
+        block = self.blocks[block_idx]
+        current_device = self.block_locations.get(block_idx)
+        if current_device == device:
+            return 0.0
+
+        if non_blocking is None:
+            non_blocking = self.config.use_non_blocking
+
+        start_time = time.time()
+
+        if self._has_nf4_layers:
+            # NF4: block.to() with non_blocking=True crashes on CUDA→CPU.
+            # Use per-parameter move instead.
+            elapsed = self._move_nf4_block_to_device(block_idx, device)
+            return elapsed
+
+        block.to(device, non_blocking=non_blocking)
+        self._fix_int8_state_devices(block, device)
+
+        if not non_blocking and device.type == "cuda":
+            torch.cuda.synchronize(device)
+
+        elapsed = time.time() - start_time
+        self.block_locations[block_idx] = device
+        self.stats.total_swap_time_seconds += elapsed
+
+        if device == self.target_device:
+            self.stats.total_swaps_to_gpu += 1
+            self.stats.blocks_currently_on_gpu += 1
+            self.stats.blocks_currently_on_cpu -= 1
+        else:
+            self.stats.total_swaps_to_cpu += 1
+            self.stats.blocks_currently_on_gpu -= 1
+            self.stats.blocks_currently_on_cpu += 1
+
         if self.config.debug:
             logger.debug(f"Block {block_idx} moved to {device} in {elapsed*1000:.1f}ms (raw)")
-        
+
         return elapsed
     
     def _move_block_to_device(
@@ -956,9 +1031,11 @@ class BlockSwapManager:
         # ALWAYS check for and wait on prefetch events first
         # This must happen BEFORE checking location because prefetch updates location optimistically
         if block_idx in self._prefetch_events:
-            if self.config.debug:
-                logger.info(f"  Waiting for prefetch event...")
-            self._prefetch_events[block_idx].synchronize()
+            event = self._prefetch_events[block_idx]
+            if event is not None:
+                if self.config.debug:
+                    logger.info(f"  Waiting for prefetch event...")
+                event.synchronize()
             del self._prefetch_events[block_idx]
         else:
             # Block wasn't prefetched, need to do sync transfer
@@ -1036,40 +1113,45 @@ class BlockSwapManager:
             # Async prefetch
             block = self.blocks[prefetch_idx]
             store = self._cpu_param_store.get(prefetch_idx)
-            
-            with torch.cuda.stream(self._prefetch_stream):
-                if self._has_nf4_layers:
-                    # NF4: must use block.to() to properly move quant_state
-                    block.to(self.target_device, non_blocking=True)
-                elif self._has_int8_layers:
-                    # INT8: must use block.to() + aliasing fix.
-                    # Pinned buffer store is skipped for INT8 (WDDM issue).
-                    block.to(self.target_device, non_blocking=True)
-                    self._fix_int8_state_devices(block, self.target_device)
-                elif store is not None:
-                    # Param-level transfers from pinned buffers (fast DMA)
-                    for name, param in block.named_parameters():
-                        if param.data.device != self.target_device:
-                            param.data = param.data.to(self.target_device, non_blocking=True)
-                    
-                    for name, buf in block.named_buffers():
-                        if buf.data.device != self.target_device:
-                            buf.data = buf.data.to(self.target_device, non_blocking=True)
-                    
-                    if self._has_int8_layers:
-                        self._fix_int8_state_devices(block, self.target_device)
-                else:
-                    # Fallback: standard block.to()
-                    block.to(self.target_device, non_blocking=True)
-                    self._fix_int8_state_devices(block, self.target_device)
-                
-                # Record event for synchronization
-                event = torch.cuda.Event()
-                event.record(self._prefetch_stream)
-                self._prefetch_events[prefetch_idx] = event
-                
+
+            if self._has_nf4_layers:
+                # NF4: block.to(non_blocking=True) crashes (cudaErrorInvalidValue).
+                # Cannot use async streams — fall back to synchronous per-param move.
+                self._move_nf4_block_to_device(prefetch_idx, self.target_device)
+                self._prefetch_events[prefetch_idx] = None  # no event needed
                 self.block_locations[prefetch_idx] = self.target_device
                 self.stats.total_swaps_to_gpu += 1
+            else:
+                with torch.cuda.stream(self._prefetch_stream):
+                    if self._has_int8_layers:
+                        # INT8: must use block.to() + aliasing fix.
+                        # Pinned buffer store is skipped for INT8 (WDDM issue).
+                        block.to(self.target_device, non_blocking=True)
+                        self._fix_int8_state_devices(block, self.target_device)
+                    elif store is not None:
+                        # Param-level transfers from pinned buffers (fast DMA)
+                        for name, param in block.named_parameters():
+                            if param.data.device != self.target_device:
+                                param.data = param.data.to(self.target_device, non_blocking=True)
+
+                        for name, buf in block.named_buffers():
+                            if buf.data.device != self.target_device:
+                                buf.data = buf.data.to(self.target_device, non_blocking=True)
+
+                        if self._has_int8_layers:
+                            self._fix_int8_state_devices(block, self.target_device)
+                    else:
+                        # Fallback: standard block.to()
+                        block.to(self.target_device, non_blocking=True)
+                        self._fix_int8_state_devices(block, self.target_device)
+
+                    # Record event for synchronization
+                    event = torch.cuda.Event()
+                    event.record(self._prefetch_stream)
+                    self._prefetch_events[prefetch_idx] = event
+
+                    self.block_locations[prefetch_idx] = self.target_device
+                    self.stats.total_swaps_to_gpu += 1
             
             if self.config.debug:
                 logger.debug(f"Prefetching block {prefetch_idx}")

--- a/hunyuan_instruct_nodes.py
+++ b/hunyuan_instruct_nodes.py
@@ -1622,21 +1622,46 @@ class HunyuanInstructLoader:
         start_time = time.time()
         
         if quant_type == "nf4":
-            # NF4 pre-quantized models: load to single GPU, no quantization_config needed
-            # These models are small enough (~24GB) to fit on one GPU
-            logger.info("Loading pre-quantized NF4 Instruct model to single GPU...")
-            model = AutoModelForCausalLM.from_pretrained(
-                model_path,
-                device_map={"": "cuda:0"},  # Single GPU, moveable
-                trust_remote_code=True,
-                torch_dtype=torch.bfloat16,
-                attn_implementation=attention_impl,
-                moe_impl=moe_impl,
-                moe_drop_tokens=True,
-                low_cpu_mem_usage=True,
-                # No quantization_config - model is pre-quantized on disk
-            )
-            model_info["is_moveable"] = True
+            # NF4 pre-quantized models: ~29GB. Strategy depends on blocks_to_swap.
+            logger.info("Loading pre-quantized NF4 Instruct model...")
+
+            if blocks_to_swap > 0 and BLOCK_SWAP_AVAILABLE:
+                # Block swap mode: load entirely to CPU, then manually place
+                # non-block components on GPU. BlockSwapManager handles the
+                # 32 transformer blocks.
+                # Params4bit.to(device) supports GPU↔CPU movement.
+                logger.info(f"  Block swap mode: loading NF4 model to CPU first...")
+                model = AutoModelForCausalLM.from_pretrained(
+                    model_path,
+                    device_map="cpu",
+                    trust_remote_code=True,
+                    torch_dtype=torch.bfloat16,
+                    attn_implementation=attention_impl,
+                    moe_impl=moe_impl,
+                    moe_drop_tokens=True,
+                    low_cpu_mem_usage=True,
+                    # No quantization_config - model is pre-quantized on disk
+                )
+                # Move non-block components to GPU (VAE, vision, embeddings, etc.)
+                logger.info("  Moving non-block components to GPU...")
+                _move_non_block_components_to_gpu(model, target_device="cuda:0", verbose=1)
+                model_info["is_moveable"] = True
+            else:
+                # No block swap: load NF4 model directly to single GPU.
+                # Requires ~48GB VRAM (29GB model + inference headroom).
+                logger.info("Loading pre-quantized NF4 Instruct model to single GPU...")
+                model = AutoModelForCausalLM.from_pretrained(
+                    model_path,
+                    device_map={"": "cuda:0"},  # Single GPU, moveable
+                    trust_remote_code=True,
+                    torch_dtype=torch.bfloat16,
+                    attn_implementation=attention_impl,
+                    moe_impl=moe_impl,
+                    moe_drop_tokens=True,
+                    low_cpu_mem_usage=True,
+                    # No quantization_config - model is pre-quantized on disk
+                )
+                model_info["is_moveable"] = True
             
         elif quant_type == "int8":
             # INT8 pre-quantized models: ~80GB. Strategy depends on blocks_to_swap.
@@ -2383,9 +2408,16 @@ class HunyuanInstructImageEdit:
                     "max": 2,
                     "tooltip": "Verbosity level. 0=silent (recommended), 1=info (shows full system prompt), 2=debug"
                 }),
+                "resolution": (RESOLUTION_LIST, {
+                    "default": "auto",
+                    "tooltip": (
+                        "Output image resolution. Auto lets the model decide based on the input image.\n"
+                        "Selecting a specific resolution overrides the input image size."
+                    )
+                }),
             }
         }
-    
+
     def edit(
         self,
         model,
@@ -2400,9 +2432,17 @@ class HunyuanInstructImageEdit:
         flow_shift: float = 2.8,
         max_new_tokens: int = 2048,
         verbose: int = 0,
+        resolution: str = "auto",
     ) -> Tuple[torch.Tensor, str, str]:
         """Edit image based on instruction."""
-        
+
+        # Parse resolution
+        res_mode, height, width = parse_resolution(resolution)
+        if res_mode == "auto":
+            image_size = "auto"
+        else:
+            image_size = f"{height}x{width}"
+
         # Convert input image to temp file
         temp_path = tensor_to_temp_path(image)
         temp_files = [temp_path]
@@ -2451,6 +2491,7 @@ class HunyuanInstructImageEdit:
             logger.info(f"Editing image:")
             logger.info(f"  Instruction: {instruction[:100]}...")
             logger.info(f"  Bot task: {bot_task}")
+            logger.info(f"  Resolution: {image_size}")
             logger.info(f"  Steps: {steps}, Seed: {seed}")
             
             start_time = time.time()
@@ -2473,7 +2514,7 @@ class HunyuanInstructImageEdit:
                 prompt=instruction,
                 image=temp_path,  # Single image path
                 seed=seed,
-                image_size="auto",
+                image_size=image_size,
                 use_system_prompt=use_system_prompt_value,
                 system_prompt=custom_system_prompt,
                 bot_task=bot_task,

--- a/hunyuan_loader_clean.py
+++ b/hunyuan_loader_clean.py
@@ -250,7 +250,10 @@ class CleanModelLoader:
             else:
                 result = cls._load_bf16(model_path, device, dtype, reserve_vram_gb)
         elif quant_type == "nf4":
-            result = cls._load_nf4(model_path, device, dtype)
+            if blocks_to_swap > 0:
+                result = cls._load_nf4_block_swap(model_path, device, dtype)
+            else:
+                result = cls._load_nf4(model_path, device, dtype)
         elif quant_type == "int8":
             if blocks_to_swap > 0:
                 result = cls._load_int8_block_swap(model_path, device, dtype)
@@ -675,7 +678,120 @@ class CleanModelLoader:
             load_time_seconds=0.0,
             uses_device_map=False
         )
-    
+
+    @classmethod
+    def _load_nf4_block_swap(
+        cls,
+        model_path: str,
+        device: str,
+        dtype: torch.dtype,
+    ) -> LoadResult:
+        """
+        Load pre-quantized NF4 model to CPU, then move non-block components to GPU.
+
+        This mirrors the proven INT8 block-swap path:
+        1. Load entire model to CPU (no quantization_config — weights are pre-quantized)
+        2. Move non-block components (VAE, embeddings, projections) to GPU
+        3. Leave 32 transformer blocks on CPU for BlockSwapManager
+        4. BlockSwapManager handles GPU↔CPU swapping during inference
+
+        Pre-quantized NF4 models store weights as Params4bit on disk.
+        Params4bit.to(device) supports GPU↔CPU movement, making block swap viable.
+        The BlockSwapManager already detects NF4 layers and uses block.to() instead
+        of the buffered path to properly handle quant_state tensors.
+
+        Returns a LoadResult with is_moveable=True (blocks can be swapped).
+        """
+        logger.info(f"Loading NF4 model from {model_path} (block-swap mode)")
+        logger.info("NF4 model → CPU first, then non-block parts to GPU")
+        logger.info("Transformer blocks will be managed by BlockSwapManager")
+
+        # Clear CUDA cache before loading
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
+            gc.collect()
+
+        # Log system RAM availability
+        try:
+            import psutil
+            ram = psutil.virtual_memory()
+            logger.info(
+                f"System RAM: {ram.available / 1024**3:.1f}GB available / "
+                f"{ram.total / 1024**3:.1f}GB total ({ram.percent:.1f}% used)"
+            )
+        except ImportError:
+            pass
+
+        # Load entirely to CPU — no quantization_config needed for pre-quantized models
+        logger.info("Loading pre-quantized NF4 model to CPU (low_cpu_mem_usage=True)...")
+        try:
+            model = AutoModelForCausalLM.from_pretrained(
+                model_path,
+                device_map="cpu",
+                trust_remote_code=True,
+                torch_dtype=dtype,
+                attn_implementation="sdpa",
+                moe_impl="eager",
+                moe_drop_tokens=True,
+                low_cpu_mem_usage=True,
+                # No quantization_config — model is pre-quantized on disk
+            )
+        except TypeError:
+            logger.warning("Falling back to minimal load args")
+            model = AutoModelForCausalLM.from_pretrained(
+                model_path,
+                device_map="cpu",
+                trust_remote_code=True,
+                torch_dtype=dtype,
+                low_cpu_mem_usage=True,
+            )
+
+        # Move non-block components to GPU
+        target = torch.device(device)
+        moved_gb = _move_non_block_components_to_gpu(model, target)
+        logger.info(f"Moved {moved_gb:.2f}GB of non-block components to {device}")
+
+        # Remove stale hf_device_map (we manage placement ourselves now)
+        if hasattr(model, "hf_device_map"):
+            delattr(model, "hf_device_map")
+
+        # Remove any accelerate dispatch hooks installed by device_map="cpu"
+        try:
+            from accelerate.hooks import remove_hook_from_module
+            for _name, module in model.named_modules():
+                if hasattr(module, "_hf_hook"):
+                    remove_hook_from_module(module)
+                # Clean up stale instance-level forward left by hook removal
+                if "forward" in vars(module):
+                    try:
+                        delattr(module, "forward")
+                    except Exception:
+                        pass
+        except (ImportError, Exception):
+            pass
+
+        # Load tokenizer
+        if hasattr(model, 'load_tokenizer'):
+            model.load_tokenizer(model_path)
+            logger.info("Tokenizer loaded")
+
+        # Ensure VAE is in full precision on GPU
+        if hasattr(model, 'vae'):
+            model.vae = model.vae.to(device=target, dtype=dtype)
+            logger.info("VAE configured in full precision (bfloat16)")
+
+        logger.info("NF4 model ready for block-swap inference")
+
+        return LoadResult(
+            model=model,
+            quant_type="nf4",
+            is_moveable=True,  # Blocks can be moved GPU↔CPU for block swap
+            device=device,
+            dtype=dtype,
+            load_time_seconds=0.0,
+            uses_device_map=False,
+        )
+
     @classmethod
     def _load_int8_block_swap(
         cls,

--- a/hunyuan_shared.py
+++ b/hunyuan_shared.py
@@ -2332,6 +2332,17 @@ def patch_hunyuan_generate_image(model):
     t2i_system_prompts = getattr(model_module, "t2i_system_prompts", None)
     default = getattr(model_module, "default", lambda val, d: val if val is not None else d)
     
+    # Determine the correct generation method at patch time.
+    # v1 models (GenerationMixin) expose _generate() internally.
+    # v2 models may only have generate() without _generate().
+    _gen_method = getattr(model, '_generate', None)
+    if _gen_method is None:
+        _gen_method = getattr(model, 'generate', None)
+        if _gen_method is not None:
+            logger.info("Model has no _generate — patch will use generate() instead")
+        else:
+            logger.warning("Model has neither _generate nor generate — patch may not work correctly")
+
     def new_generate_image(
             self,
             prompt,
@@ -2365,7 +2376,7 @@ def patch_hunyuan_generate_image(model):
                 prompt=prompt, bot_task=bot_task, system_prompt=system_prompt, max_new_tokens=max_new_tokens)
             print(f"<{bot_task}>", end="", flush=True)
             # Do NOT pass callback_on_step_end here
-            outputs = self._generate(**model_inputs, **kwargs, verbose=verbose)
+            outputs = _gen_method(**model_inputs, **kwargs, verbose=verbose)
             cot_text = self.get_cot_text(outputs[0])
             # Switch system_prompt to `en_recaption` if drop_think is enabled.
             if self.generation_config.drop_think and system_prompt:
@@ -2378,7 +2389,7 @@ def patch_hunyuan_generate_image(model):
             model_inputs = self.prepare_model_inputs(
                 prompt=prompt, cot_text=cot_text, bot_task="img_ratio", system_prompt=system_prompt, seed=seed)
             # Do NOT pass callback_on_step_end here
-            outputs = self._generate(**model_inputs, **kwargs, verbose=verbose)
+            outputs = _gen_method(**model_inputs, **kwargs, verbose=verbose)
             ratio_index = outputs[0, -1].item() - self._tkwrapper.ratio_token_offset
             # In some cases, the generated ratio_index is out of range. A valid ratio_index should be in [0, 32].
             # If ratio_index is out of range, we set it to 16 (i.e., 1:1).
@@ -2392,16 +2403,16 @@ def patch_hunyuan_generate_image(model):
             prompt=prompt, cot_text=cot_text, system_prompt=system_prompt, mode="gen_image", seed=seed,
             image_size=image_size,
         )
-        
+
         # Ensure we don't pass callback_on_step_end if it's None, just to be safe
         gen_kwargs = kwargs.copy()
         if callback_on_step_end is not None:
             gen_kwargs["callback_on_step_end"] = callback_on_step_end
         if latents is not None:  # LATENT CONTROL: pass through custom latents
             gen_kwargs["latents"] = latents
-            
+
         # PASS callback_on_step_end here
-        outputs = self._generate(**model_inputs, **gen_kwargs, verbose=verbose)
+        outputs = _gen_method(**model_inputs, **gen_kwargs, verbose=verbose)
         return outputs[0]
 
     logger.info("Patching model.generate_image to support progress bars...")


### PR DESCRIPTION
- Add NF4 block-swap path to both InstructLoader and CleanLoader, loading model to CPU then moving non-block components to GPU for BlockSwapManager to handle the 32 transformer blocks
- Fix NF4 block movement: use per-parameter moves instead of block.to() to avoid cudaErrorInvalidValue on CUDA→CPU transfers
- Fall back to synchronous prefetch for NF4 (no CUDA events)
- Add `_generate`/`generate` fallback detection in patch_hunyuan_generate_image for v2 model compatibility
- Add resolution selector to HunyuanInstructImageEdit node (default "auto")

---
Fixes: #32, #23

---
Tested manually with `Hunyuan Instruct Loader` and with `Hunyuan Unified Generate V2` - on 3090 (24 VRAM) + 64 RAM  with `HunyuanImage-3-Instruct-Distil-NF4-v2`
- generate image `1024x1024` works with `block_to_swap` = 25 (VRAM 23.3 used)
- edit image (Hunyuan Instruct Image Edit) works with input image scaled to `1024x1024`, output image set to `1024x1024` with `blocks_to_swap` = 31 (VRAM = 20.8 used, so probably will work with ~29 blocks too).