### PR TITLE
Add experimental low-memory BF16 disk offload

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+README.md -text
+hunyuan_instruct_nodes.py -text
+LOW_MEMORY_BF16.md text eol=lf
+README_WORKFLOWS_SECTION.md text eol=lf
+workflows/*.md text eol=lf
+workflows/*.json text eol=lf
+tools/*.bat text eol=crlf

--- a/LOW_MEMORY_BF16.md
+++ b/LOW_MEMORY_BF16.md
@@ -1,0 +1,528 @@
+# Experimental Low-Memory BF16 Disk Offload
+
+This document describes the unofficial low-memory loading path added by the
+[foxidermist fork](https://github.com/foxidermist/Comfy_HunyuanImage3) of
+`EricRollei/Comfy_HunyuanImage3`.
+
+The goal is to run the full
+`tencent/HunyuanImage-3.0-Instruct` BF16 checkpoint using a combination of:
+
+- a small CUDA model budget;
+- a capped physical-RAM model budget;
+- disk-backed sharded `safetensors`;
+- Windows pagefile or operating-system swap;
+- targeted compatibility fixes for modules that otherwise remain on the
+  PyTorch `meta` device.
+
+This is an experimental compatibility mode, not a fast consumer-GPU mode.
+
+## Status
+
+A complete image-edit generation has been successfully produced with the
+configuration below.
+
+| Component | Tested value |
+|---|---|
+| Operating system | Windows |
+| GPU | NVIDIA RTX 5070 |
+| VRAM | 12 GB |
+| System RAM | 64 GB |
+| Windows pagefile | 96 GB |
+| Checkpoint | Full `HunyuanImage-3.0-Instruct` BF16 |
+| PyTorch | `2.13.0+cu130` |
+| Transformers | `4.57.6` |
+| Accelerate | `1.14.0` |
+| Initial successful test | 4 diffusion steps, `bot_task=image` |
+| Approximate speed | 2.5–3 minutes per diffusion step |
+
+Results on other systems are not guaranteed.
+
+## Why This Mode Exists
+
+The full BF16 checkpoint is approximately 160 GB. Normal execution expects a
+large GPU, multiple GPUs, or enough physical RAM to keep the weights resident.
+
+The low-memory path instead asks Accelerate to distribute modules across:
+
+```text
+cuda:0
+cpu
+disk
+```
+
+Disk-mapped modules are materialized only when they are needed. This reduces
+persistent VRAM and RAM use, but makes inference dominated by SSD reads and
+PCIe transfers.
+
+Low average GPU utilization is therefore normal. The GPU often finishes a
+short computation and waits for the next module's weights.
+
+## Scope of the Modifications
+
+The fork adds or changes the following behavior in
+`hunyuan_instruct_nodes.py`:
+
+1. BF16 CUDA/CPU/disk loading with `device_map="auto"`.
+2. Configurable CPU model-memory budget.
+3. Portable disk-offload directory selection.
+4. Low-VRAM GPU budget handling.
+5. Physical RAM, virtual memory, free disk space, and final device-map logs.
+6. Fallback for a missing `config.model_version`.
+7. Compatibility alias for image-processor method-name drift.
+8. SigLIP2 positional-embedding materialization through its module hook.
+9. Accelerate submodule preloading for `torch.nn.MultiheadAttention`.
+
+The original prompt processing, CFG behavior, VAE generation path, NF4/INT8
+loading, and existing block-swap implementation are otherwise preserved.
+
+## Important Security Note
+
+Instruct checkpoints require:
+
+```python
+trust_remote_code=True
+```
+
+This executes Python code supplied with the model repository. Download model
+files only from a source you trust and review unexpected remote-code changes.
+
+## Installation
+
+### 1. Clone the Fork
+
+From the `ComfyUI/custom_nodes` directory:
+
+```bash
+git clone https://github.com/foxidermist/Comfy_HunyuanImage3.git
+```
+
+Restart ComfyUI after installation.
+
+### 2. Install the Standard Requirements
+
+Using the Python environment that runs ComfyUI:
+
+```bash
+cd Comfy_HunyuanImage3
+python -m pip install -r requirements.txt
+```
+
+For the Windows portable build, use the embedded interpreter rather than a
+different system Python.
+
+Example:
+
+```bat
+C:\ComfyUI\python_embeded\python.exe -m pip install -r requirements.txt
+```
+
+### 3. Install the Tested Transformers and Accelerate Versions
+
+Completely close ComfyUI first.
+
+If the repository includes the helper script, run:
+
+```bat
+tools\fix_hunyuan_accelerate_transformers.bat
+```
+
+Equivalent manual command for the standard portable path:
+
+```bat
+C:\ComfyUI\python_embeded\python.exe -m pip uninstall -y accelerate transformers
+C:\ComfyUI\python_embeded\python.exe -m pip install --no-cache-dir "accelerate==1.14.0" "transformers==4.57.6"
+```
+
+Verify:
+
+```bat
+C:\ComfyUI\python_embeded\python.exe -c "import accelerate, transformers; print('accelerate:', accelerate.__version__); print('transformers:', transformers.__version__)"
+```
+
+Expected:
+
+```text
+accelerate: 1.14.0
+transformers: 4.57.6
+```
+
+Transformers 5.x may work for other project modes, but it caused native
+checkpoint-loader crashes in the tested full-BF16 disk-offload environment.
+The pin above documents the verified combination rather than a universal
+requirement for every ComfyUI setup.
+
+## Model Installation
+
+Download the official checkpoint:
+
+```bash
+huggingface-cli download tencent/HunyuanImage-3.0-Instruct \
+  --local-dir HunyuanImage-3.0-Instruct
+```
+
+The model can be stored directly under:
+
+```text
+ComfyUI/models/HunyuanImage-3.0-Instruct
+```
+
+A separate fast drive is usually preferable because the checkpoint is large
+and disk traffic is continuous during generation.
+
+For an external model directory, add a category to
+`extra_model_paths.yaml`:
+
+```yaml
+comfyui:
+  hunyuan_instruct: |
+    D:/Models
+```
+
+With this example, the model directory is:
+
+```text
+D:/Models/HunyuanImage-3.0-Instruct
+```
+
+The Python loader does not require a hard-coded checkpoint path.
+
+## Portable Disk-Offload Directory
+
+The default auxiliary offload directory is selected by platform.
+
+### Windows
+
+```text
+%LOCALAPPDATA%\ComfyUI\HunyuanImage3\disk_offload
+```
+
+### Linux
+
+```text
+$XDG_CACHE_HOME/ComfyUI/HunyuanImage3/disk_offload
+```
+
+or, when `XDG_CACHE_HOME` is unset:
+
+```text
+~/.cache/ComfyUI/HunyuanImage3/disk_offload
+```
+
+### macOS
+
+```text
+~/Library/Caches/ComfyUI/HunyuanImage3/disk_offload
+```
+
+Override the default without modifying Python.
+
+### Windows BAT
+
+```bat
+set "HUNYUAN_DISK_OFFLOAD_DIR=D:\HunyuanDiskOffload"
+```
+
+### PowerShell
+
+```powershell
+$env:HUNYUAN_DISK_OFFLOAD_DIR = "D:\HunyuanDiskOffload"
+```
+
+### Linux or macOS
+
+```bash
+export HUNYUAN_DISK_OFFLOAD_DIR=/mnt/fastssd/HunyuanDiskOffload
+```
+
+A path entered directly in the loader's `disk_offload_dir` field takes
+priority for that workflow.
+
+## Why the Offload Directory May Be Empty
+
+An empty auxiliary offload folder does not prove that disk offload is
+inactive.
+
+When the checkpoint consists of sharded `safetensors`, Transformers and
+Accelerate can use the original checkpoint files as the disk backing store.
+In that case:
+
+- the configured offload directory may contain no large files;
+- the original model drive shows substantial read activity;
+- parameters not currently active remain on the PyTorch `meta` device;
+- the log still reports modules mapped to `disk`.
+
+Confirm the active mode from logs such as:
+
+```text
+Model distributed across: 0, cpu, disk
+SSD disk offload active: 33 modules mapped to disk
+```
+
+The exact module count can vary with library versions, available memory, and
+checkpoint structure.
+
+## Recommended Loader Settings
+
+For the tested 12 GB VRAM / 64 GB RAM machine:
+
+| Loader option | Value |
+|---|---|
+| `quant_type` | `bf16` |
+| `attention_impl` | `sdpa` |
+| `moe_impl` | `eager` |
+| `vram_reserve_gb` | `5` |
+| `blocks_to_swap` | `0` |
+| `moe_drop_tokens` | `true` |
+| `vae_dtype` | `bfloat16` |
+| `use_disk_offload` | `true` |
+| `cpu_memory_limit_gb` | `16` |
+| `disk_offload_dir` | Default or a fast local SSD path |
+
+The disk-offload path is used only for BF16 when `blocks_to_swap=0`.
+Existing quantized and block-swap modes follow their original loading paths.
+
+## Initial Workflow Test
+
+Use conservative settings for the first run:
+
+| Generation option | Initial test value |
+|---|---|
+| `bot_task` | `image` |
+| Steps | `4` |
+| Input image | Approximately `512×512` where practical |
+| Resolution | `Auto` or a modest model-native bucket |
+| Number of input images | `1` |
+
+The full Instruct model is not CFG-distilled. It uses CFG with batch size 2,
+which doubles major inference tensors compared with the distilled model.
+
+Increasing the number of diffusion steps increases runtime but usually does
+not reduce peak memory. Test stability before increasing resolution or using
+recaption modes.
+
+## Expected Startup Logs
+
+A successful low-memory load should include messages similar to:
+
+```text
+Loading BF16 Instruct model with SSD disk offload...
+SSD offload GPU budget: 5.0 GiB
+SSD offload CPU budget: 16 GiB
+Loading checkpoint shards: 100%
+Model distributed across: 0, cpu, disk
+SSD disk offload active: ... modules mapped to disk
+Loading tokenizer...
+Compatibility fix: config.model_version was missing
+Compatibility fix: aliased image_processor...
+Compatibility fix: patched SigLIP2 positional embedding access...
+Compatibility fix: enabled Accelerate submodule preloading for MultiheadAttention...
+```
+
+The important device-map condition is the presence of all three targets:
+
+```text
+0, cpu, disk
+```
+
+A `cpu, disk` map without GPU target `0` makes CPU the main execution device
+and is not the intended tested configuration.
+
+## Windows Pagefile Guidance
+
+The tested machine used:
+
+```text
+98304 MB
+```
+
+for both the initial and maximum Windows pagefile size.
+
+This is not a universal minimum. Required virtual memory depends on physical
+RAM, checkpoint mapping, library versions, and other running applications.
+
+Reducing the pagefile can work, but it also reduces the Windows commit limit.
+During a cold model load, monitor:
+
+```text
+Task Manager → Performance → Memory → Committed
+```
+
+Keep substantial headroom between committed memory and the commit limit.
+Windows error 1455 indicates that the paging file or commit limit is too
+small for the requested allocation.
+
+Restart Windows after changing the pagefile size.
+
+## Resource Utilization and Performance
+
+The tested configuration is I/O-bound.
+
+Typical observations include:
+
+- low or bursty GPU utilization;
+- VRAM use far below the physical 12 GB capacity between module calls;
+- moderate physical-RAM use despite a 160 GB checkpoint;
+- heavy reads from the drive containing the checkpoint;
+- several minutes per diffusion step.
+
+This behavior is expected. Accelerate repeatedly materializes the active
+module, performs its computation, and releases or offloads it.
+
+Increasing `cpu_memory_limit_gb` from 16 to 24 or 32 may reduce disk traffic
+when enough RAM is available. Test one change at a time and preserve virtual
+memory headroom.
+
+Do not increase the GPU model budget merely because average VRAM usage appears
+low. Short-lived MoE, CFG, attention, and VAE peaks may occur between
+monitoring samples.
+
+## Compatibility Fixes Explained
+
+### Missing `config.model_version`
+
+Some Instruct configurations omit `model_version`, while the tokenizer loader
+expects it. The fork assigns:
+
+```text
+HunyuanImage-3.0
+```
+
+only when the attribute is absent.
+
+### Image-Processor Method Name
+
+Some model-code revisions call:
+
+```text
+build_img_ratio_slice_logits_proc
+```
+
+while the loaded processor provides:
+
+```text
+build_img_ratio_slice_logits_processor
+```
+
+The fork adds a compatibility alias.
+
+### SigLIP2 Positional Embeddings on `meta`
+
+The model code reads positional-embedding weights directly. Direct access can
+bypass an Accelerate child-module hook, leaving the tensor on `meta`.
+
+The fork invokes the embedding module normally so Accelerate can materialize
+and offload it correctly.
+
+### `MultiheadAttention.out_proj` on `meta`
+
+PyTorch's `MultiheadAttention` accesses the child `out_proj` weights inside
+its functional implementation rather than calling `out_proj.forward()`.
+
+The fork enables Accelerate submodule preloading on the parent attention
+module, ensuring the child weights are real tensors during the operation.
+
+## Troubleshooting
+
+### `AttributeError: ... model_version`
+
+Confirm that this fork's `hunyuan_instruct_nodes.py` is installed and that
+ComfyUI was fully restarted.
+
+### `build_img_ratio_slice_logits_proc` Is Missing
+
+The public fork includes an alias for the longer processor method name.
+A stale Python file or cached old custom-node installation is the usual cause.
+
+### `Tensor on device meta is not on the expected device cuda:0`
+
+Check the traceback.
+
+If it references:
+
+```text
+position_embedding
+```
+
+the SigLIP2 compatibility patch did not load.
+
+If it references:
+
+```text
+MultiheadAttention
+out_proj_weight
+```
+
+the Accelerate submodule-preloading patch did not load.
+
+Confirm the corresponding compatibility messages appear during model startup.
+
+### Windows Error 1455
+
+Increase the Windows pagefile, close memory-heavy applications, restart
+Windows, and retry a cold load.
+
+### CUDA Out of Memory
+
+Start with:
+
+- `bot_task=image`;
+- one `512×512` reference image;
+- four steps;
+- `moe_drop_tokens=true`;
+- a modest output bucket.
+
+Recaption and `think_recaption` modes can require dramatically more memory
+than direct image mode.
+
+### Model Loads but Generation Appears Frozen
+
+Check disk activity. A single step may take several minutes. Disk-backed
+execution can remain silent between progress updates while tens of gigabytes
+of weights are read.
+
+### The Offload Folder Is Empty
+
+This can be normal with directly mapped sharded safetensors. Verify the final
+device map and disk-module count in the log.
+
+## Unsupported or Discouraged Combinations
+
+Avoid the following unless you are deliberately testing a new path:
+
+- BF16 disk offload with `blocks_to_swap > 0`;
+- Soft Unload on a model containing `meta` parameters;
+- `think_recaption` on a 12 GB GPU;
+- very large input or output resolutions on the first run;
+- updating Transformers without preserving the last working environment;
+- copying model weights into the Git repository.
+
+## Publishing and Contributions
+
+When publishing changes based on this fork:
+
+- retain the original copyright and license notices;
+- credit Eric Hiss / EricRollei as the original integration author;
+- identify the low-memory work as an unofficial adaptation;
+- document tested hardware and dependency versions;
+- do not include Tencent model weights in the repository;
+- avoid implying endorsement by Tencent, Hugging Face, ComfyUI, Accelerate, or
+  the upstream project.
+
+A clean contribution should include:
+
+```text
+hunyuan_instruct_nodes.py
+LOW_MEMORY_BF16.md
+README.md
+tools/fix_hunyuan_accelerate_transformers.bat
+patches/hunyuan_instruct_nodes_original_to_public.patch
+```
+
+## Credits
+
+- Original ComfyUI integration: Eric Hiss / EricRollei
+- HunyuanImage-3.0 model: Tencent Hunyuan Team
+- Low-memory fork and testing: foxidermist
+- Development and debugging assistance: OpenAI ChatGPT
+
+This fork is unofficial and experimental.

--- a/README.md
+++ b/README.md
@@ -23,6 +23,22 @@ Professional ComfyUI custom nodes for [Tencent HunyuanImage-3.0](https://github.
 
 > **🙏 Acknowledgment**: This project integrates the HunyuanImage-3.0 model developed by **Tencent Hunyuan Team** and uses their official system prompts. The model and original code are licensed under [Apache 2.0](https://github.com/Tencent-Hunyuan/HunyuanImage-3.0/blob/main/LICENSE). This integration code is separately licensed under CC BY-NC 4.0 for non-commercial use.
 
+
+> [!IMPORTANT]
+> **Unofficial low-memory fork by [foxidermist](https://github.com/foxidermist).**
+> This fork adds an experimental CUDA/CPU/disk-backed loading path for the full
+> `HunyuanImage-3.0-Instruct` BF16 checkpoint on systems that cannot hold the
+> model in GPU VRAM or physical RAM.
+>
+> A complete image-edit generation was successfully tested on an NVIDIA RTX
+> 5070 with 12 GB VRAM, 64 GB system RAM, and a 96 GB Windows pagefile. This
+> mode is extremely slow and remains experimental. It does not replace the
+> upstream hardware recommendations for normal full-BF16 operation.
+>
+> See **[LOW_MEMORY_BF16.md](LOW_MEMORY_BF16.md)** for installation, tested
+> dependency versions, loader settings, expected logs, troubleshooting, and
+> limitations.
+
 ## 📋 TODO / Known Issues
 
 - [x] **NF4 Low VRAM Loader**: Custom device map keeps NF4 layers on GPU so 24‑32 GB cards can use the Low VRAM Budget workflow without bitsandbytes errors.
@@ -38,6 +54,7 @@ Professional ComfyUI custom nodes for [Tencent HunyuanImage-3.0](https://github.
 
 - **Multiple Loading Modes**: Full BF16, INT8/NF4 Quantized, Single GPU, Multi-GPU
 - **Smart Memory Management**: Automatic VRAM tracking, cleanup, and optimization
+- **Experimental Full-BF16 Disk Offload**: Run the full Instruct BF16 checkpoint using CUDA, capped CPU RAM, and disk-backed safetensors on otherwise unsupported low-memory systems
 - **High-Quality Image Generation**: 
   - Standard generation (<2MP) - Fast, GPU-only
   - Large image generation (2MP-8MP+) - CPU offload support
@@ -66,6 +83,13 @@ Professional ComfyUI custom nodes for [Tencent HunyuanImage-3.0](https://github.
 - **Minimum 80GB VRAM** (or multi-GPU) for full BF16 model
 - Python 3.10+
 - PyTorch 2.9+ with CUDA 12.8+ (recommended for best performance)
+
+
+> [!NOTE]
+> The minimum-VRAM figures above describe the normal upstream loading paths.
+> The experimental low-memory BF16 mode in this fork has separately been tested
+> with 12 GB VRAM and 64 GB RAM by streaming most BF16 weights from disk. It is
+> dramatically slower and requires substantial virtual memory.
 
 ### System Requirements & Hardware Recommendations
 
@@ -130,19 +154,60 @@ Both variants are available in BF16, INT8, and NF4 quantization.
 | Instruct (full) | INT8 | ~81 GB | 96 GB | Required | ✅ Working |
 | Instruct (full) | BF16 | ~160 GB | 96 GB | Required | ✅ Working |
 
+
+#### Experimental Full-BF16 Instruct Disk Offload (This Fork)
+
+This fork adds a separate loading mode for systems far below the normal
+full-BF16 memory envelope. It uses an Accelerate device map spanning CUDA,
+CPU RAM, and disk-backed safetensors.
+
+| Component | Tested configuration |
+|---|---|
+| GPU | NVIDIA RTX 5070, 12 GB VRAM |
+| System RAM | 64 GB |
+| Virtual memory | 96 GB Windows pagefile |
+| Checkpoint | `tencent/HunyuanImage-3.0-Instruct`, full BF16 |
+| Transformers | `4.57.6` |
+| Accelerate | `1.14.0` |
+| Loader mode | BF16, disk offload enabled, block swap disabled |
+| Performance | Approximately 2.5–3 minutes per diffusion step in the tested workflow |
+
+This mode is intended for experimentation, compatibility testing, and users
+who accept severe I/O bottlenecks. A quantized checkpoint or a larger GPU is
+still preferable for routine work.
+
+See [LOW_MEMORY_BF16.md](LOW_MEMORY_BF16.md) before enabling this mode.
+
 ### Quick Install
 
 1. **Clone this repository** into your ComfyUI custom nodes folder:
 ```bash
 cd ComfyUI/custom_nodes
-git clone https://github.com/ericRollei/Eric_Hunyuan3.git
+git clone https://github.com/foxidermist/Comfy_HunyuanImage3.git
 ```
 
 2. **Install dependencies**:
 ```bash
-cd Eric_Hunyuan3
+cd Comfy_HunyuanImage3
 pip install -r requirements.txt
 ```
+
+
+For the tested Windows low-memory BF16 path, completely close ComfyUI and run:
+
+```bat
+tools\fix_hunyuan_accelerate_transformers.bat
+```
+
+The helper pins the versions used during successful testing:
+
+```text
+accelerate==1.14.0
+transformers==4.57.6
+```
+
+Do not apply these pins blindly to an unrelated ComfyUI installation. They
+are documented for this fork's experimental full-BF16 Instruct path.
 
 3. **Download model weights**:
 
@@ -377,8 +442,45 @@ The **HunyuanImage-3.0-Instruct** models extend the base model with powerful new
 | `force_reload` | Force reload even if cached | False |
 | `attention_impl` | Attention implementation (`sdpa` recommended) | sdpa |
 | `moe_impl` | MoE implementation (keep `eager` unless you have flashinfer) | eager |
-| `vram_reserve_gb` | VRAM to keep free for inference (auto-boosted for CFG models) | 30.0 |
+| `vram_reserve_gb` | VRAM reserved for inference. Low-memory GPUs are clamped to a tested 5 GB reserve | 8.0 |
 | `blocks_to_swap` | Number of transformer blocks to swap between GPU↔CPU (0 = no swap) | 0 |
+| `moe_drop_tokens` | Limit MoE expert capacity to reduce peak memory | True |
+| `vae_dtype` | VAE decode precision (`bfloat16` or `float32`) | bfloat16 |
+| `use_disk_offload` | For BF16 with `blocks_to_swap=0`, allow CUDA/CPU/disk placement | True |
+| `disk_offload_dir` | Portable Accelerate offload/cache directory; may remain empty when source safetensors are mapped directly | Platform cache directory |
+| `cpu_memory_limit_gb` | Maximum physical-RAM budget used for BF16 model placement | 32 |
+
+
+### Experimental BF16 Disk-Offload Quick Start
+
+For the successfully tested 12 GB VRAM / 64 GB RAM configuration:
+
+| Setting | Value |
+|---|---|
+| `quant_type` | `bf16` |
+| `blocks_to_swap` | `0` |
+| `use_disk_offload` | `true` |
+| `vram_reserve_gb` | `5` |
+| `cpu_memory_limit_gb` | `16` |
+| `moe_drop_tokens` | `true` |
+| `vae_dtype` | `bfloat16` |
+| `bot_task` | `image` |
+| Initial test steps | `4` |
+| Initial input size | `512×512` where practical |
+
+The loader should report a device map containing all three targets:
+
+```text
+Model distributed across: 0, cpu, disk
+```
+
+It should also report one or more modules mapped to disk. An empty
+`disk_offload_dir` does not necessarily mean disk offload is inactive:
+Transformers and Accelerate may read individual tensors directly from the
+original sharded `safetensors` files.
+
+Full setup and troubleshooting are documented in
+[LOW_MEMORY_BF16.md](LOW_MEMORY_BF16.md).
 
 ### Block Swap (VRAM Management)
 
@@ -573,6 +675,20 @@ python hunyuan_quantize_instruct_distil_nf4.py \
 3. **RAM usage accumulates** — The Instruct Unload node clears the model cache, but some references may persist across successive loads. If you notice RAM creeping up, restart ComfyUI. A fix is planned.
 
 4. **Instruct models need `trust_remote_code=True`** — The loader handles this automatically. The Instruct models include custom model code that must be executed.
+
+
+5. **Experimental BF16 disk offload is I/O-bound** — Most model weights may be
+   read from sharded `safetensors` for every active module. Low average GPU and
+   RAM utilization is expected because the GPU frequently waits for disk and
+   PCIe transfers.
+
+6. **Soft Unload is not compatible with disk-mapped models** — Models loaded
+   with an Accelerate `device_map` contain `meta` parameters and should be fully
+   unloaded or ComfyUI should be restarted instead.
+
+7. **The offload directory may remain empty** — With sharded safetensors,
+   Accelerate can use the original checkpoint files as the disk backing store.
+   Confirm operation from the logged `hf_device_map`, not from folder size.
 
 ---
 
@@ -1230,6 +1346,27 @@ Copyright (c) 2025-2026 Eric Hiss. All rights reserved.
 
 ## 🔄 Changelog
 
+
+### Unreleased Fork Changes
+
+**Experimental low-memory full-BF16 Instruct support:**
+
+- Added CUDA/CPU/disk device mapping for BF16 Instruct models
+- Added configurable physical-RAM and disk-offload budgets
+- Added portable offload-directory selection and
+  `HUNYUAN_DISK_OFFLOAD_DIR` override
+- Added Windows pagefile / Linux and macOS swap diagnostics
+- Added a compatibility fallback for missing `config.model_version`
+- Added an image-processor method alias for upstream API drift
+- Fixed SigLIP2 positional embeddings remaining on the `meta` device
+- Fixed `MultiheadAttention.out_proj` remaining on `meta` during offload
+- Added logging for the final device map and disk-mapped module count
+- Documented the successfully tested 12 GB VRAM / 64 GB RAM configuration
+
+These changes affect loading, device placement, diagnostics, and compatibility.
+The original generation, CFG, VAE, quantized loading, and block-swap paths are
+otherwise retained.
+
 ### v1.3.0 (2026-02-12)
 
 **INT8 Instruct Fix (5 bugs):**
@@ -1291,3 +1428,13 @@ Copyright (c) 2025-2026 Eric Hiss. All rights reserved.
 ---
 
 **Made with ❤️ for the ComfyUI community**
+
+## Example Low-Memory Workflows
+
+Ready-to-import ComfyUI workflows are included in [`workflows/`](workflows/):
+
+- [Full-BF16 Text to Image](workflows/HunyuanImage3_Instruct_BF16_DiskOffload_TextToImage.json)
+- [Full-BF16 Image to Image](workflows/HunyuanImage3_Instruct_BF16_DiskOffload_ImageToImage.json)
+
+Both examples use disk offload, no block swap, direct `image` mode, and 40
+steps. See [`workflows/README.md`](workflows/README.md) before running them.

--- a/hunyuan_instruct_nodes.py
+++ b/hunyuan_instruct_nodes.py
@@ -1,22 +1,28 @@
 """
 HunyuanImage-3.0 Instruct Nodes for ComfyUI
 
-Dedicated nodes for the new HunyuanImage-3.0-Instruct and Instruct-Distil models.
+Dedicated nodes for the HunyuanImage-3.0-Instruct and Instruct-Distil models.
 These models support:
 - Built-in prompt enhancement (no external API needed)
 - Chain-of-Thought (CoT) reasoning
 - Image-to-Image editing
 - Multi-image fusion (up to 3 images)
 - Block swap for NF4, INT8, and BF16 (CPU↔GPU block swapping)
+- Experimental low-memory BF16 CUDA/CPU/disk offload
 
-Author: Eric Hiss (GitHub: EricRollei)
+Original author: Eric Hiss (GitHub: EricRollei)
 License: Dual License (Non-Commercial and Commercial Use)
 Copyright (c) 2025-2026 Eric Hiss. All rights reserved.
+
+This is an unofficial low-memory adaptation. It preserves the original
+generation logic while adding portable disk-offload configuration and
+compatibility fixes for offloaded HunyuanImage/SigLIP2 modules.
 """
 
 import gc
 import logging
 import os
+import sys
 import tempfile
 import time
 from typing import Any, Dict, List, Optional, Tuple, Union
@@ -42,11 +48,9 @@ try:
         get_available_hunyuan_models,
         patch_dynamic_cache_dtype,
         patch_hunyuan_static_cache_device,
-        patch_model_device_meta_safe,
         patch_pipeline_pre_vae_cleanup,
         patch_static_cache_lazy_init,
         patch_to_device_for_instruct,
-        strip_accelerate_hooks_from_vae,
         clear_generation_cache,
         resolve_hunyuan_model_path,
     )
@@ -58,11 +62,9 @@ except ImportError:
             get_available_hunyuan_models,
             patch_dynamic_cache_dtype,
             patch_hunyuan_static_cache_device,
-            patch_model_device_meta_safe,
             patch_pipeline_pre_vae_cleanup,
             patch_static_cache_lazy_init,
             patch_to_device_for_instruct,
-            strip_accelerate_hooks_from_vae,
             clear_generation_cache,
             resolve_hunyuan_model_path,
         )
@@ -71,11 +73,9 @@ except ImportError:
         SHARED_UTILS_AVAILABLE = False
         patch_dynamic_cache_dtype = None
         patch_hunyuan_static_cache_device = None
-        patch_model_device_meta_safe = None
         patch_pipeline_pre_vae_cleanup = None
         patch_static_cache_lazy_init = None
         patch_to_device_for_instruct = None
-        strip_accelerate_hooks_from_vae = None
         clear_generation_cache = None
 
 # Import block swap manager
@@ -92,6 +92,372 @@ except ImportError:
         BlockSwapManager = None
 
 logger = logging.getLogger(__name__)
+
+# =============================================================================
+# Portable BF16 SSD offload configuration
+# =============================================================================
+
+def _default_bf16_disk_offload_dir() -> str:
+    """Return a writable, platform-appropriate default offload directory.
+
+    The location can be overridden without editing this file by setting the
+    ``HUNYUAN_DISK_OFFLOAD_DIR`` environment variable.
+    """
+    override = os.environ.get("HUNYUAN_DISK_OFFLOAD_DIR", "").strip()
+    if override:
+        return os.path.abspath(
+            os.path.expanduser(os.path.expandvars(override))
+        )
+
+    home = os.path.expanduser("~")
+
+    if os.name == "nt":
+        cache_root = os.environ.get("LOCALAPPDATA")
+        if not cache_root:
+            cache_root = os.path.join(home, "AppData", "Local")
+    elif sys.platform == "darwin":
+        cache_root = os.path.join(home, "Library", "Caches")
+    else:
+        cache_root = os.environ.get("XDG_CACHE_HOME")
+        if not cache_root:
+            cache_root = os.path.join(home, ".cache")
+
+    return os.path.join(
+        cache_root,
+        "ComfyUI",
+        "HunyuanImage3",
+        "disk_offload",
+    )
+
+
+# The full BF16 checkpoint is larger than the memory available on many
+# consumer systems. Accelerate can keep most modules backed by safetensors on
+# disk and materialize them only while each module is being executed.
+DEFAULT_BF16_DISK_OFFLOAD_DIR = _default_bf16_disk_offload_dir()
+DEFAULT_BF16_CPU_MEMORY_LIMIT_GIB = 32
+LOW_VRAM_THRESHOLD_GIB = 24.0
+LOW_VRAM_RESERVE_GIB = 5.0
+# At least one indivisible Hunyuan transformer module needs about 4.65 GiB.
+# A smaller budget yields a cpu+disk-only map, making CPU the execution device.
+LOW_VRAM_GPU_MODEL_BUDGET_GIB = 5.0
+
+
+def _prepare_bf16_disk_offload(
+    model_path: str,
+    offload_root: str,
+    requested_cpu_limit_gib: int,
+    requested_vram_reserve_gib: float,
+) -> Tuple[str, Dict[Any, Any]]:
+    """Prepare an Accelerate device map budget for BF16 SSD offload.
+
+    The checkpoint remains in ``model_path``. Accelerate may use the original
+    sharded safetensors directly or create auxiliary files under
+    ``offload_root/<model-name>``. CPU RAM is deliberately capped so the
+    operating system retains headroom; pagefile or swap may still be required.
+    """
+    import psutil
+    import shutil
+
+    model_name = os.path.basename(os.path.normpath(model_path)) or "HunyuanImage3"
+    safe_name = "".join(c if c.isalnum() or c in "-_." else "_" for c in model_name)
+
+    normalized_offload_root = (offload_root or "").strip()
+    if not normalized_offload_root:
+        normalized_offload_root = DEFAULT_BF16_DISK_OFFLOAD_DIR
+    normalized_offload_root = os.path.abspath(
+        os.path.expanduser(os.path.expandvars(normalized_offload_root))
+    )
+
+    offload_dir = os.path.join(normalized_offload_root, safe_name)
+    os.makedirs(offload_dir, exist_ok=True)
+
+    ram = psutil.virtual_memory()
+    swap = psutil.swap_memory()
+    available_ram_gib = ram.available / 1024**3
+    total_ram_gib = ram.total / 1024**3
+    pagefile_total_gib = swap.total / 1024**3
+    pagefile_free_gib = swap.free / 1024**3
+    estimated_commit_limit_gib = total_ram_gib + pagefile_total_gib
+
+    # Accelerate's max_memory["cpu"] is a placement budget, not a requirement
+    # that at least 16 GiB must be resident in physical RAM.  A small budget is
+    # valid when most modules are assigned to the explicit SSD offload folder.
+    # Keep roughly 8 GiB of currently available RAM outside the model budget for
+    # Windows, ComfyUI, Python, CUDA bookkeeping and transient shard loading.
+    if available_ram_gib < 8.0:
+        raise RuntimeError(
+            f"Too little free physical RAM to start BF16 disk offload: "
+            f"{available_ram_gib:.1f} GiB available. Close other programs and retry."
+        )
+
+    max_safe_cpu_gib = max(4, int(available_ram_gib - 8.0))
+    safe_cpu_limit = int(max(4, min(requested_cpu_limit_gib, max_safe_cpu_gib)))
+    if safe_cpu_limit != requested_cpu_limit_gib:
+        logger.warning(
+            f"  CPU placement budget reduced from {requested_cpu_limit_gib} GiB "
+            f"to {safe_cpu_limit} GiB to preserve host-memory headroom."
+        )
+
+    logger.info(
+        f"  Physical RAM: {available_ram_gib:.1f} GiB available / "
+        f"{total_ram_gib:.1f} GiB total"
+    )
+    virtual_memory_name = "Windows pagefile" if os.name == "nt" else "Swap"
+    logger.info(
+        f"  {virtual_memory_name}: {pagefile_free_gib:.1f} GiB free / "
+        f"{pagefile_total_gib:.1f} GiB total; estimated RAM + virtual-memory "
+        f"limit ~{estimated_commit_limit_gib:.1f} GiB"
+    )
+    if estimated_commit_limit_gib < 185.0:
+        if os.name == "nt":
+            logger.warning(
+                "  The RAM + pagefile commit limit is below ~185 GiB. "
+                "Windows may raise OS error 1455 while Transformers maps "
+                "the ~160 GiB checkpoint and creates temporary loading objects."
+            )
+        else:
+            logger.warning(
+                "  RAM + swap is below ~185 GiB. Loading the full BF16 "
+                "checkpoint may fail if temporary allocations exceed the "
+                "available virtual-memory limit."
+            )
+
+    max_memory: Dict[Any, Any] = {}
+
+    if torch.cuda.is_available():
+        free_bytes, _ = torch.cuda.mem_get_info(0)
+        free_vram_gib = free_bytes / 1024**3
+        # Keep the resident model budget tiny.  Disk/CPU modules are copied to
+        # the execution GPU only for their forward pass.
+        usable_after_reserve = max(1.0, free_vram_gib - requested_vram_reserve_gib)
+        gpu_budget_gib = max(1.0, min(LOW_VRAM_GPU_MODEL_BUDGET_GIB, usable_after_reserve))
+        max_memory[0] = f"{gpu_budget_gib:.0f}GiB"
+        logger.info(
+            f"  SSD offload GPU budget: {gpu_budget_gib:.1f} GiB; "
+            f"requested inference reserve: {requested_vram_reserve_gib:.1f} GiB"
+        )
+        if gpu_budget_gib < 4.7:
+            logger.warning(
+                "  GPU placement budget is below the ~4.65 GiB minimum module size. "
+                "Accelerate may create a cpu+disk-only map. Lower vram_reserve_gb "
+                "to 5 GiB and retry so CUDA becomes the execution device."
+            )
+
+    # Keep CPU last in max_memory so Accelerate considers CUDA before CPU.
+    max_memory["cpu"] = f"{safe_cpu_limit}GiB"
+
+    try:
+        disk = shutil.disk_usage(offload_dir)
+        disk_free_gib = disk.free / 1024**3
+        logger.info(f"  SSD offload directory: {offload_dir}")
+        logger.info(f"  SSD free space: {disk_free_gib:.1f} GiB")
+        if disk_free_gib < 170:
+            logger.warning(
+                "  Less than 170 GiB is free in the SSD offload location. "
+                "The BF16 offload cache may not fit."
+            )
+    except Exception as exc:
+        logger.warning(f"  Could not inspect SSD free space: {exc}")
+
+    logger.info(
+        f"  SSD offload CPU budget: {safe_cpu_limit} GiB "
+        f"({available_ram_gib:.1f} GiB currently available)"
+    )
+    return offload_dir, max_memory
+
+
+def _patch_siglip2_position_embedding_for_disk_offload(model: Any) -> bool:
+    """Fix SigLIP2 positional embeddings when their nn.Embedding is disk-offloaded.
+
+    The official Siglip2VisionEmbeddings.forward() reads
+    ``self.position_embedding.weight`` directly instead of calling the
+    registered ``nn.Embedding`` submodule. Accelerate attaches the SSD/CPU
+    materialization hook to that submodule, so direct weight access leaves the
+    parameter on the meta device.
+
+    This patch keeps Accelerate's hook wrapper intact and replaces only the
+    wrapped implementation. Calling ``self.position_embedding(position_ids)``
+    triggers the normal pre/post hooks: the tiny positional table is loaded
+    for the operation and can be offloaded again immediately afterwards.
+    """
+    import types
+
+    vision_model = getattr(model, "vision_model", None)
+    embeddings = getattr(vision_model, "embeddings", None)
+    position_embedding = getattr(embeddings, "position_embedding", None)
+
+    if embeddings is None or position_embedding is None:
+        logger.debug("  SigLIP2 disk-offload patch skipped: embeddings not found")
+        return False
+
+    if getattr(embeddings, "_hunyuan_position_embedding_offload_patch", False):
+        return True
+
+    def _disk_safe_embeddings_forward(
+        self,
+        pixel_values: torch.FloatTensor,
+        spatial_shapes: torch.LongTensor,
+    ) -> torch.Tensor:
+        # patch_embedding is called normally, so its Accelerate hook can
+        # materialize an offloaded weight before the linear projection.
+        target_dtype = self.patch_embedding.weight.dtype
+        patch_embeds = self.patch_embedding(pixel_values.to(dtype=target_dtype))
+
+        # CRITICAL: invoke the nn.Embedding module instead of reading
+        # position_embedding.weight directly. The module call activates its
+        # Accelerate hook and returns a real tensor rather than a meta tensor.
+        position_ids = torch.arange(
+            self.num_patches,
+            device=patch_embeds.device,
+            dtype=torch.long,
+        )
+        positional_embeddings = self.position_embedding(position_ids)
+        positional_embeddings = positional_embeddings.reshape(
+            self.position_embedding_size,
+            self.position_embedding_size,
+            -1,
+        )
+
+        resized_positional_embeddings = self.resize_positional_embeddings(
+            positional_embeddings,
+            spatial_shapes,
+            max_length=pixel_values.shape[1],
+        )
+        if resized_positional_embeddings.device != patch_embeds.device:
+            resized_positional_embeddings = resized_positional_embeddings.to(
+                device=patch_embeds.device,
+                dtype=patch_embeds.dtype,
+            )
+        elif resized_positional_embeddings.dtype != patch_embeds.dtype:
+            resized_positional_embeddings = resized_positional_embeddings.to(
+                dtype=patch_embeds.dtype
+            )
+
+        return patch_embeds + resized_positional_embeddings
+
+    patched_forward = types.MethodType(_disk_safe_embeddings_forward, embeddings)
+
+    # Accelerate wraps module.forward and stores the original callable in
+    # _old_forward. Replacing _old_forward preserves the pre/post offload hook.
+    if hasattr(embeddings, "_old_forward"):
+        embeddings._old_forward = patched_forward
+        patch_target = "_old_forward (Accelerate hook preserved)"
+    else:
+        embeddings.forward = patched_forward
+        patch_target = "forward"
+
+    embeddings._hunyuan_position_embedding_offload_patch = True
+
+    mapped_device = None
+    device_map = getattr(model, "hf_device_map", None)
+    if isinstance(device_map, dict):
+        full_name = "vision_model.embeddings.position_embedding"
+        best_prefix = ""
+        for module_name, device in device_map.items():
+            if (
+                full_name == module_name
+                or full_name.startswith(module_name + ".")
+                or module_name == ""
+            ):
+                if len(module_name) >= len(best_prefix):
+                    best_prefix = module_name
+                    mapped_device = device
+
+    logger.warning(
+        "  Compatibility fix: patched SigLIP2 positional embedding access for "
+        f"SSD/CPU offload via {patch_target}"
+        + (
+            f" (device-map target: {mapped_device})."
+            if mapped_device is not None
+            else "."
+        )
+    )
+    return True
+
+
+def _patch_multihead_attention_offload_hooks(model: Any) -> int:
+    """Make Accelerate preload child weights of nn.MultiheadAttention.
+
+    PyTorch's MultiheadAttention.forward() uses ``out_proj.weight`` and
+    ``out_proj.bias`` directly inside ``F.multi_head_attention_forward``.
+    It does not call ``out_proj.forward()``, so an Accelerate hook attached
+    only to the child Linear module never fires.  When that child is CPU/disk
+    offloaded, its tensors therefore remain on the meta device.
+
+    Setting ``place_submodules=True`` on the parent MHA AlignDevicesHook makes
+    its pre-forward materialize both the direct MHA parameters and parameters
+    of registered child modules.  The corresponding post-forward then
+    offloads them again, preserving the low-memory execution model.
+    """
+
+    def _enable_on_hook(hook: Any) -> bool:
+        changed = False
+
+        if hasattr(hook, "place_submodules"):
+            if not bool(getattr(hook, "place_submodules")):
+                hook.place_submodules = True
+                changed = True
+
+        # Accelerate may wrap several hooks in a SequentialHook.
+        nested = getattr(hook, "hooks", None)
+        if nested:
+            for child_hook in nested:
+                changed = _enable_on_hook(child_hook) or changed
+
+        return changed
+
+    patched = 0
+    already_enabled = 0
+    meta_out_proj = 0
+
+    for module_name, module in model.named_modules():
+        if not isinstance(module, torch.nn.MultiheadAttention):
+            continue
+
+        out_proj = getattr(module, "out_proj", None)
+        if out_proj is not None:
+            for param in out_proj.parameters(recurse=False):
+                if getattr(param, "device", None) is not None and param.device.type == "meta":
+                    meta_out_proj += 1
+                    break
+
+        hook = getattr(module, "_hf_hook", None)
+        if hook is None:
+            continue
+
+        if _enable_on_hook(hook):
+            patched += 1
+            logger.warning(
+                "  Compatibility fix: enabled Accelerate submodule preloading "
+                f"for MultiheadAttention '{module_name}'."
+            )
+        else:
+            # Count hooks that already expose an enabled place_submodules flag.
+            hook_stack = [hook]
+            enabled = False
+            while hook_stack:
+                current = hook_stack.pop()
+                if bool(getattr(current, "place_submodules", False)):
+                    enabled = True
+                    break
+                nested = getattr(current, "hooks", None)
+                if nested:
+                    hook_stack.extend(nested)
+            if enabled:
+                already_enabled += 1
+
+    if patched or already_enabled:
+        logger.warning(
+            "  MultiheadAttention offload compatibility: "
+            f"{patched} hooks patched, {already_enabled} already compatible; "
+            f"{meta_out_proj} modules had meta out_proj parameters."
+        )
+    else:
+        logger.debug(
+            "  MultiheadAttention offload patch found no Accelerate hooks to modify."
+        )
+
+    return patched
 
 # =============================================================================
 # Constants and Configuration
@@ -176,13 +542,6 @@ INSTRUCT_RESOLUTION_PRESETS = {
 }
 
 RESOLUTION_LIST = list(INSTRUCT_RESOLUTION_PRESETS.keys())
-
-# Legacy alias: older saved workflows stored the raw value "auto" instead of
-# the display key "Auto (model predicts)". Keep the dict entry so
-# parse_resolution() resolves it, but do NOT add it to RESOLUTION_LIST (would
-# create a duplicate "auto" entry in the dropdown). Old workflows loading with
-# "auto" will need the user to re-pick "Auto (model predicts)" once.
-INSTRUCT_RESOLUTION_PRESETS.setdefault("auto", "auto")
 
 
 # =============================================================================
@@ -719,29 +1078,6 @@ def parse_resolution(resolution_name: str) -> Tuple[str, Optional[int], Optional
     else:
         height, width = value
         return ("fixed", height, width)
-
-
-# Numeric bucket list (H, W), excluding non-tuple sentinel entries like "auto".
-_BUCKET_HW = [v for v in INSTRUCT_RESOLUTION_PRESETS.values() if isinstance(v, tuple)]
-
-
-def pick_bucket_for_image(input_h: int, input_w: int) -> Tuple[int, int]:
-    """Return the trained bucket (H, W) closest in aspect ratio to the input.
-
-    Used for image-edit "auto" mode: instead of letting the model pick a
-    generic 1024x1024 bucket, match the input aspect ratio while capping
-    at the trained ~1MP base size. This keeps edited outputs the same shape
-    as the input (downscaled to a supported bucket if larger).
-    """
-    if input_h <= 0 or input_w <= 0:
-        return (1024, 1024)
-    import math
-    target_log_ar = math.log(input_w / input_h)
-    best = min(
-        _BUCKET_HW,
-        key=lambda hw: abs(math.log(hw[1] / hw[0]) - target_log_ar),
-    )
-    return best
 
 
 def _aggressive_vram_cleanup(model: Any, context: str = "generation") -> None:
@@ -1495,8 +1831,8 @@ class HunyuanInstructLoader:
                     "tooltip": "MoE implementation. flashinfer is faster but requires flashinfer package."
                 }),
                 "vram_reserve_gb": ("FLOAT", {
-                    "default": 30.0,
-                    "min": 5.0,
+                    "default": 8.0,
+                    "min": 1.0,
                     "max": 80.0,
                     "step": 1.0,
                     "tooltip": (
@@ -1553,6 +1889,30 @@ class HunyuanInstructLoader:
                         "via ComfyUI launch flag.)"
                     )
                 }),
+                "use_disk_offload": ("BOOLEAN", {
+                    "default": True,
+                    "tooltip": (
+                        "For BF16 with blocks_to_swap=0, keep most weights as memory-mapped "
+                        "files on SSD instead of requiring 150+ GB of physical RAM. "
+                        "This is experimental and extremely slow."
+                    )
+                }),
+                "disk_offload_dir": ("STRING", {
+                    "default": DEFAULT_BF16_DISK_OFFLOAD_DIR,
+                    "tooltip": "SSD directory used by Accelerate for BF16 memory-mapped offload files."
+                }),
+                "cpu_memory_limit_gb": ("INT", {
+                    "default": DEFAULT_BF16_CPU_MEMORY_LIMIT_GIB,
+                    "min": 8,
+                    "max": 192,
+                    "step": 1,
+                    "tooltip": (
+                        "Maximum physical-RAM placement budget for BF16 loading. "
+                        "Use 8–16 GB for maximum SSD offload, or 24–32 GB for "
+                        "better speed when enough RAM is free. Pagefile capacity is "
+                        "reported separately and is not counted as physical RAM."
+                    )
+                }),
             }
         }
     
@@ -1566,6 +1926,9 @@ class HunyuanInstructLoader:
         blocks_to_swap: int = 0,
         moe_drop_tokens: bool = True,
         vae_dtype: str = "bfloat16",
+        use_disk_offload: bool = True,
+        disk_offload_dir: str = DEFAULT_BF16_DISK_OFFLOAD_DIR,
+        cpu_memory_limit_gb: int = DEFAULT_BF16_CPU_MEMORY_LIMIT_GIB,
     ) -> Tuple[Any]:
         """Load the Instruct model (BF16, INT8, or NF4)."""
         from transformers import AutoModelForCausalLM
@@ -1630,6 +1993,18 @@ class HunyuanInstructLoader:
         logger.info(f"  Type: {model_info['model_type']}")
         logger.info(f"  Quantization: {quant_type}")
         logger.info(f"  Default steps: {model_info['default_steps']}")
+
+        total_vram_gib = 0.0
+        if torch.cuda.is_available():
+            total_vram_gib = torch.cuda.get_device_properties(0).total_memory / 1024**3
+        low_vram_mode = 0 < total_vram_gib < LOW_VRAM_THRESHOLD_GIB
+        if low_vram_mode and vram_reserve_gb > LOW_VRAM_RESERVE_GIB:
+            logger.warning(
+                f"  Low-VRAM GPU detected ({total_vram_gib:.1f} GiB). "
+                f"Clamping vram_reserve_gb from {vram_reserve_gb:.1f} to "
+                f"{LOW_VRAM_RESERVE_GIB:.1f} GiB."
+            )
+            vram_reserve_gb = LOW_VRAM_RESERVE_GIB
         
         # CRITICAL: Full Instruct models (cfg_distilled=False) use CFG with batch=2.
         # This DOUBLES all inference tensors:
@@ -1646,7 +2021,14 @@ class HunyuanInstructLoader:
             # Auto-boost vram_reserve if user left it at default and it's too low for CFG.
             # For CFG models, 30GB reserve is barely enough for bot_task=image at 1024x1024.
             # We recommend at least 40GB for safety.
-            if vram_reserve_gb <= 30.0:
+            if low_vram_mode:
+                logger.warning(
+                    "    Full Instruct CFG on a sub-24-GiB GPU is below the supported "
+                    "memory envelope. The loader will keep the reserve at the low-VRAM "
+                    "value and use SSD offload, but generation may still OOM."
+                )
+                logger.info("    TIP: Use bot_task='image', 512x512 input, and the fewest practical steps.")
+            elif vram_reserve_gb <= 30.0:
                 original_reserve = vram_reserve_gb
                 vram_reserve_gb = 40.0
                 logger.info(f"    Auto-boosted vram_reserve: {original_reserve:.0f}GB → {vram_reserve_gb:.0f}GB "
@@ -1905,37 +2287,112 @@ class HunyuanInstructLoader:
                 _move_non_block_components_to_gpu(model, target_device="cuda:0", verbose=1)
                 model_info["is_moveable"] = True
             else:
-                # No block swap: use explicit device map to distribute across GPUs.
-                # All transformer layers stay on GPU 0 (or CPU-offloaded to GPU 0).
-                # Secondary GPUs only get VAE/vision to avoid dispatch_mask OOM.
-                logger.info("Loading BF16 Instruct model with explicit device map...")
-                logger.info(f"  Primary GPU reserve: {vram_reserve_gb:.1f}GB "
-                           f"(covers MoE dispatch_mask + KV cache for think_recaption)")
-                explicit_map, max_memory = create_device_map_for_instruct(
-                    reserve_min_gb=vram_reserve_gb,
-                    model_size_gb=160.0,  # BF16 model is ~160GB
-                )
-                model = AutoModelForCausalLM.from_pretrained(
-                    model_path,
-                    attn_implementation=attention_impl,
-                    trust_remote_code=True,
-                    torch_dtype=torch.bfloat16,
-                    device_map=explicit_map,
-                    max_memory=max_memory,
-                    moe_impl=moe_impl,
-                    moe_drop_tokens=moe_drop_tokens,
-                )
+                # No block swap.  On this user's 12 GB GPU / 64 GB RAM machine,
+                # physical RAM cannot hold the ~160 GB BF16 model.  Use Accelerate's
+                # real SSD offload rather than Windows paging.
+                if use_disk_offload:
+                    logger.info("Loading BF16 Instruct model with SSD disk offload...")
+                    offload_dir, max_memory = _prepare_bf16_disk_offload(
+                        model_path=model_path,
+                        offload_root=disk_offload_dir,
+                        requested_cpu_limit_gib=cpu_memory_limit_gb,
+                        requested_vram_reserve_gib=vram_reserve_gb,
+                    )
+                    model = AutoModelForCausalLM.from_pretrained(
+                        model_path,
+                        attn_implementation=attention_impl,
+                        trust_remote_code=True,
+                        torch_dtype=torch.bfloat16,
+                        device_map="auto",
+                        max_memory=max_memory,
+                        offload_folder=offload_dir,
+                        offload_state_dict=True,
+                        low_cpu_mem_usage=True,
+                        moe_impl=moe_impl,
+                        moe_drop_tokens=moe_drop_tokens,
+                    )
+                    model_info["disk_offload"] = True
+                    model_info["offload_dir"] = offload_dir
+                else:
+                    # Original high-memory path: explicit GPU + CPU placement.
+                    logger.info("Loading BF16 Instruct model with explicit device map...")
+                    logger.info(f"  Primary GPU reserve: {vram_reserve_gb:.1f}GB "
+                               f"(covers MoE dispatch_mask + KV cache for think_recaption)")
+                    explicit_map, max_memory = create_device_map_for_instruct(
+                        reserve_min_gb=vram_reserve_gb,
+                        model_size_gb=160.0,  # BF16 model is ~160GB
+                    )
+                    model = AutoModelForCausalLM.from_pretrained(
+                        model_path,
+                        attn_implementation=attention_impl,
+                        trust_remote_code=True,
+                        torch_dtype=torch.bfloat16,
+                        device_map=explicit_map,
+                        max_memory=max_memory,
+                        low_cpu_mem_usage=True,
+                        moe_impl=moe_impl,
+                        moe_drop_tokens=moe_drop_tokens,
+                    )
                 model_info["is_moveable"] = False
         
         # Log actual device placement
         if hasattr(model, 'hf_device_map'):
             devices_used = set(str(v) for v in model.hf_device_map.values())
             logger.info(f"Model distributed across: {', '.join(sorted(devices_used))}")
+            disk_modules = [name for name, dev in model.hf_device_map.items() if str(dev) == "disk"]
+            if disk_modules:
+                logger.info(f"  SSD disk offload active: {len(disk_modules)} modules mapped to disk")
+                logger.info(f"  Offload directory: {model_info.get('offload_dir', disk_offload_dir)}")
         
-        # Load tokenizer
+        # Load tokenizer.  The official Instruct config currently omits
+        # ``model_version`` while its remote ``load_tokenizer`` implementation
+        # unconditionally reads ``self.config.model_version``.  Transformers 4.x
+        # therefore raises AttributeError after the weights have loaded.  The
+        # base HunyuanImage-3.0 config uses this exact value.
         logger.info("Loading tokenizer...")
+        if not hasattr(model.config, "model_version"):
+            model.config.model_version = "HunyuanImage-3.0"
+            logger.warning(
+                "  Compatibility fix: config.model_version was missing; "
+                "using 'HunyuanImage-3.0' for tokenizer initialization."
+            )
         model.load_tokenizer(model_path)
-        
+
+        # Compatibility shim for the official Instruct remote code.  At the
+        # time of writing, modeling_hunyuan_image_3.py calls the legacy/short
+        # method name ``build_img_ratio_slice_logits_proc`` while
+        # image_processor.py exposes
+        # ``build_img_ratio_slice_logits_processor``.  Add an instance alias
+        # instead of editing the Hugging Face module cache, so the fix survives
+        # cache refreshes and remains limited to this loaded model.
+        image_processor = getattr(model, "image_processor", None)
+        if image_processor is not None:
+            legacy_ratio_builder = "build_img_ratio_slice_logits_proc"
+            current_ratio_builder = "build_img_ratio_slice_logits_processor"
+            if (
+                not hasattr(image_processor, legacy_ratio_builder)
+                and hasattr(image_processor, current_ratio_builder)
+            ):
+                setattr(
+                    image_processor,
+                    legacy_ratio_builder,
+                    getattr(image_processor, current_ratio_builder),
+                )
+                logger.warning(
+                    "  Compatibility fix: aliased image_processor."
+                    "build_img_ratio_slice_logits_proc to "
+                    "build_img_ratio_slice_logits_processor."
+                )
+
+
+        # Accelerate cannot materialize the SigLIP2 positional embedding when
+        # the official forward reads ``position_embedding.weight`` directly.
+        # Replace that one implementation with a module call so its disk/CPU
+        # offload hook runs normally.
+        if model_info.get("disk_offload"):
+            _patch_siglip2_position_embedding_for_disk_offload(model)
+            _patch_multihead_attention_offload_hooks(model)
+
         # Apply critical patches for memory management and dtype compatibility
         if SHARED_UTILS_AVAILABLE:
             logger.info("Applying dtype compatibility patches...")
@@ -1959,19 +2416,6 @@ class HunyuanInstructLoader:
             # Fix HunyuanStaticCache device mismatch on multi-GPU setups
             if patch_hunyuan_static_cache_device:
                 patch_hunyuan_static_cache_device(model)
-
-            # Fix model.device returning 'meta' when buffers are stuck on the
-            # meta device (happens with device_map="cpu" + low_cpu_mem_usage=True
-            # + block-swap). Without this, upstream prepare_model_inputs crashes
-            # with: RuntimeError: META device type not an accelerator.
-            if patch_model_device_meta_safe:
-                patch_model_device_meta_safe(model)
-
-            # Strip accelerate hooks from the VAE — it's already on a single
-            # GPU and the hook chain causes super() __class__ closure breakage
-            # across repeated invocations.
-            if strip_accelerate_hooks_from_vae:
-                strip_accelerate_hooks_from_vae(model)
         
         # Setup block swap for models with blocks_to_swap > 0
         # Works for NF4 (proven), INT8 (Int8Params.to() supports device movement),
@@ -2033,39 +2477,6 @@ class HunyuanInstructLoader:
                 _vae_dev = next(model.vae.parameters()).device
                 model.vae = model.vae.to(dtype=torch.float32)
                 logger.info(f"VAE cast to float32 (device={_vae_dev}) for higher decode precision")
-
-                # Instruct edit path: VAE-encoded conditional images flow into
-                # `model.patch_embed` (a bf16 Conv2d on the main transformer).
-                # When the VAE is fp32, the encoded latents come out in fp32 and
-                # crash patch_embed with a dtype mismatch. Wrap patch_embed to
-                # cast its input to the conv weight's dtype.
-                if hasattr(model, "patch_embed") and not getattr(
-                    model.patch_embed, "_eric_dtype_patched", False
-                ):
-                    _orig_pe_forward = model.patch_embed.forward
-
-                    def _patched_patch_embed_forward(images, *args, **kwargs):
-                        try:
-                            _w = next(model.patch_embed.parameters())
-                            _target_dtype = _w.dtype
-                            if isinstance(images, torch.Tensor) and images.dtype != _target_dtype:
-                                images = images.to(dtype=_target_dtype)
-                            elif isinstance(images, (list, tuple)):
-                                images = type(images)(
-                                    img.to(dtype=_target_dtype)
-                                    if isinstance(img, torch.Tensor) and img.dtype != _target_dtype
-                                    else img
-                                    for img in images
-                                )
-                        except StopIteration:
-                            pass
-                        return _orig_pe_forward(images, *args, **kwargs)
-
-                    model.patch_embed.forward = _patched_patch_embed_forward
-                    model.patch_embed._eric_dtype_patched = True
-                    logger.info(
-                        "Applied patch_embed input-dtype cast (fp32 VAE → bf16 patch_embed compat)"
-                    )
             except Exception as e:
                 logger.warning(f"Could not cast VAE to float32: {e}")
 
@@ -2337,22 +2748,6 @@ class HunyuanInstructGenerate:
         # from previous runs which can hold 1-4GB of VRAM
         _aggressive_vram_cleanup(model, context="T2I generation")
 
-        # Defensive: patch model.device to skip meta tensors. Idempotent
-        # (no-op if already patched). Catches models already in cache that
-        # were loaded before this fix was installed.
-        if SHARED_UTILS_AVAILABLE and patch_model_device_meta_safe:
-            try:
-                patch_model_device_meta_safe(model)
-            except Exception:
-                pass
-
-        # Defensive: strip accelerate hooks from VAE (idempotent).
-        if SHARED_UTILS_AVAILABLE and strip_accelerate_hooks_from_vae:
-            try:
-                strip_accelerate_hooks_from_vae(model)
-            except Exception:
-                pass
-
         # Propagate user VAE preferences to the patched decode wrapper (read
         # by patch_pipeline_pre_vae_cleanup at decode time).
         model._vae_tiling_mode = vae_tiling
@@ -2550,17 +2945,7 @@ class HunyuanInstructImageEdit:
                 }),
                 "align_output_size": ("BOOLEAN", {
                     "default": True,
-                    "tooltip": (
-                        "When resolution='auto':\n"
-                        "  True (default): generate at the input image's exact "
-                        "dimensions (snapped to a multiple of 16 for VAE/patch "
-                        "alignment). The default bucket-snapping in the upstream "
-                        "image_processor is bypassed for this call so 2K+ inputs "
-                        "stay at 2K+. Higher resolutions use significantly more VRAM.\n"
-                        "  False: let upstream pick the closest trained "
-                        "aspect-ratio bucket (~1MP).\n"
-                        "Ignored when resolution is set to a specific preset."
-                    )
+                    "tooltip": "Match output size to input image size (ignored unless resolution=auto)"
                 }),
                 "resolution": (RESOLUTION_LIST, {
                     "default": "auto",
@@ -2689,22 +3074,6 @@ class HunyuanInstructImageEdit:
             
             # Aggressive VRAM cleanup before image edit - clears stale KV cache
             _aggressive_vram_cleanup(model, context="image edit")
-
-            # Defensive: patch model.device to skip meta tensors (idempotent).
-            if SHARED_UTILS_AVAILABLE and patch_model_device_meta_safe:
-                try:
-                    patch_model_device_meta_safe(model)
-                except Exception:
-                    pass
-
-            # Defensive: strip accelerate hooks from VAE (idempotent).
-            # Required to prevent super() __class__ closure breakage across
-            # repeated edit invocations on the cached model.
-            if SHARED_UTILS_AVAILABLE and strip_accelerate_hooks_from_vae:
-                try:
-                    strip_accelerate_hooks_from_vae(model)
-                except Exception:
-                    pass
             
             logger.info(f"Starting image edit with bot_task='{bot_task}' "
                         f"(this may take several minutes for recaption modes)...")
@@ -2719,262 +3088,22 @@ class HunyuanInstructImageEdit:
             # NOTE: No torch.inference_mode() — conflicts with accelerate hooks
             res_mode, height, width = parse_resolution(resolution)
             if res_mode == "auto":
-                in_h, in_w = int(image.shape[1]), int(image.shape[2])
-                if align_output_size:
-                    # Snap input dims to /16 for VAE/patch alignment, then
-                    # generate at that exact size. The actual bucket bypass
-                    # is done below via the get_target_size monkey-patch.
-                    snap = 16
-                    out_h = max(snap, (in_h // snap) * snap)
-                    out_w = max(snap, (in_w // snap) * snap)
-                    image_size = f"{out_h}x{out_w}"
-                    logger.info(
-                        f"  Resolution: {image_size} "
-                        f"(matched input {in_h}x{in_w}, snapped to /{snap})"
-                    )
-                else:
-                    image_size = "auto"
-                    logger.info(f"  Resolution: {image_size} (model picks bucket)")
-                pass_align = False
+                image_size = "auto"
             else:
                 image_size = f"{height}x{width}"
-                logger.info(f"  Resolution: {image_size}")
-                pass_align = False
-
-            # Bucket bypass + diagnostic logging.
-            #
-            # Default upstream behavior: image_processor.vae_reso_group
-            # .get_target_size(w, h) snaps any requested HxW to the closest
-            # trained aspect-ratio bucket at base_size=1024 (~1MP). To honor
-            # the caller's exact requested HxW (e.g. 2048x1360), wrap
-            # get_target_size with a passthrough. We also wrap
-            # build_gen_image_info so we can log the actual ImageInfo dims
-            # that get fed into the diffusion call. This is invaluable for
-            # tracking down where a downsample is being introduced.
-            _orig_get_target_size = None
-            _orig_build_gen_image_info = None
-            _patched_reso_group = None
-            _patched_image_processor = None
-            _trace_call_count = {"get_target_size": 0, "build_gen_image_info": 0}
-            try:
-                if hasattr(model, "image_processor"):
-                    _patched_image_processor = model.image_processor
-                    _patched_reso_group = (
-                        getattr(_patched_image_processor, "vae_reso_group", None)
-                        or getattr(_patched_image_processor, "reso_group", None)
-                    )
-
-                if _patched_reso_group is not None:
-                    _orig_get_target_size = _patched_reso_group.get_target_size
-                    _bypass_enabled = (image_size != "auto")
-
-                    def _traced_get_target_size(
-                        w, h,
-                        _rg=_patched_reso_group,
-                        _orig=_orig_get_target_size,
-                        _bypass=_bypass_enabled,
-                    ):
-                        _trace_call_count["get_target_size"] += 1
-                        n = _trace_call_count["get_target_size"]
-                        try:
-                            orig_w, orig_h = _orig(w, h)
-                        except Exception as _e:
-                            orig_w, orig_h = (None, None)
-                        if _bypass:
-                            # Snap to /16 — required by VAE/patch alignment.
-                            # vae_process_image asserts divisibility by
-                            # (h_factor, w_factor) == (16, 16). This is also
-                            # called on the cond INPUT image's origin_size
-                            # (e.g. 2325x3127), not just the gen output dims.
-                            snap = 16
-                            out_w = max(snap, (int(w) // snap) * snap)
-                            out_h = max(snap, (int(h) // snap) * snap)
-                            logger.info(
-                                f"  [trace #{n}] get_target_size(w={w}, h={h}) "
-                                f"-> bypass returns (w={out_w}, h={out_h}) "
-                                f"[snapped to /{snap}]; upstream would have "
-                                f"returned (w={orig_w}, h={orig_h})"
-                            )
-                            return out_w, out_h
-                        else:
-                            logger.info(
-                                f"  [trace #{n}] get_target_size(w={w}, h={h}) "
-                                f"-> upstream (w={orig_w}, h={orig_h}); "
-                                f"bypass disabled (image_size='auto')"
-                            )
-                            return orig_w, orig_h
-
-                    _patched_reso_group.get_target_size = _traced_get_target_size
-                    logger.info(
-                        f"  Bucket bypass: get_target_size wrapped on "
-                        f"{type(_patched_reso_group).__name__} "
-                        f"(id={id(_patched_reso_group)}, base_size="
-                        f"{getattr(_patched_reso_group, 'base_size', '?')}); "
-                        f"bypass={'enabled' if _bypass_enabled else 'disabled'}"
-                    )
-
-                if _patched_image_processor is not None and hasattr(
-                    _patched_image_processor, "build_gen_image_info"
-                ):
-                    _orig_build_gen_image_info = _patched_image_processor.build_gen_image_info
-
-                    def _traced_build_gen_image_info(
-                        image_size_arg, *a, _orig=_orig_build_gen_image_info, **kw
-                    ):
-                        _trace_call_count["build_gen_image_info"] += 1
-                        n = _trace_call_count["build_gen_image_info"]
-                        info = _orig(image_size_arg, *a, **kw)
-                        logger.info(
-                            f"  [trace #{n}] build_gen_image_info("
-                            f"image_size={image_size_arg!r}) -> ImageInfo("
-                            f"image_width={getattr(info, 'image_width', '?')}, "
-                            f"image_height={getattr(info, 'image_height', '?')}, "
-                            f"token_width={getattr(info, 'token_width', '?')}, "
-                            f"token_height={getattr(info, 'token_height', '?')}, "
-                            f"base_size={getattr(info, 'base_size', '?')}, "
-                            f"ratio_index={getattr(info, 'ratio_index', '?')})"
-                        )
-                        return info
-
-                    _patched_image_processor.build_gen_image_info = _traced_build_gen_image_info
-
-                logger.info(
-                    f"  Calling generate_image with image_size={image_size!r}, "
-                    f"bot_task={bot_task!r}, infer_align_image_size={pass_align}"
-                )
-
-                # Auto-bump max_length to fit large images. The model
-                # tokenizes each image at (W/16) * (H/16) tokens; an image
-                # edit puts BOTH a cond image AND a gen image in the
-                # sequence, plus siglip vision tokens (~1024) and the text
-                # prompt. Default generation_config.max_length is 22800,
-                # which is fine for ~1MP but overflows at 2K+ inputs.
-                #
-                # NOTE: generate_image() does NOT forward **kwargs to
-                # prepare_model_inputs (see modeling_hunyuan_image_3.py
-                # ~line 3377), so passing max_length= as a kwarg is silently
-                # dropped. We must set it on generation_config instead and
-                # restore after the call.
-                # Auto-bump BOTH `generation_config.max_length` AND
-                # `model.config.max_position_embeddings` to fit large images.
-                #
-                # `max_length` (default 22800) gates the chat-template /
-                # input prep stage (`preprocess_inputs`).
-                #
-                # `max_position_embeddings` (also 22800 in this checkpoint)
-                # is used at line ~2144 of modeling_hunyuan_image_3.py:
-                #     seqlen = self.config.max_position_embeddings
-                # and that seqlen is fed to `build_2d_rope`, which iterates
-                # image slices and computes `last_pos = L + w*h`. If
-                # `last_pos > seqlen`, the final `torch.arange(last_pos,
-                # seqlen)` raises "upper bound and lower bound inconsistent
-                # with step sign".
-                #
-                # RoPE is computed analytically from positions (no learned
-                # lookup table), so positions beyond the trained range work
-                # mechanically; quality may degrade at never-trained
-                # positions but it will run.
-                #
-                # NOTE: generate_image() does NOT forward **kwargs to
-                # prepare_model_inputs (see modeling_hunyuan_image_3.py
-                # ~line 3377/3383), so passing max_length= as a kwarg is
-                # silently dropped. We mutate the model state directly.
-                _orig_max_length = None
-                _orig_max_pos = None
-                try:
-                    if res_mode == "auto" and align_output_size:
-                        _w, _h = out_w, out_h
-                    elif res_mode == "fixed":
-                        _w, _h = int(width), int(height)
-                    else:
-                        _w, _h = None, None
-                    if _w is not None and _h is not None:
-                        per_image_tokens = (_w // 16) * (_h // 16)
-                        # cond + gen + siglip(~1024) + text/system prompt
-                        # buffer (max_new_tokens covers the worst case).
-                        needed = (
-                            2 * per_image_tokens
-                            + 1024
-                            + int(max_new_tokens or 2048)
-                            + 1024  # safety margin for chat template tokens
-                        )
-                        cfg_max = int(getattr(model.generation_config, "max_length", 22800))
-                        if needed > cfg_max:
-                            _orig_max_length = model.generation_config.max_length
-                            model.generation_config.max_length = needed
-                            logger.info(
-                                f"  Auto-bumping generation_config.max_length: "
-                                f"{cfg_max} -> {needed} (2x{per_image_tokens} "
-                                f"image tokens for {_w}x{_h} + buffers)"
-                            )
-                        # Also bump max_position_embeddings on the model
-                        # config: forward() copies it into seqlen which
-                        # feeds build_2d_rope.
-                        try:
-                            mpe_obj = model.config
-                            cur_mpe = int(getattr(mpe_obj, "max_position_embeddings", 22800))
-                            if needed > cur_mpe:
-                                _orig_max_pos = mpe_obj.max_position_embeddings
-                                mpe_obj.max_position_embeddings = needed
-                                logger.info(
-                                    f"  Auto-bumping config.max_position_embeddings: "
-                                    f"{cur_mpe} -> {needed} (RoPE will extrapolate "
-                                    f"beyond trained range; quality may degrade)"
-                                )
-                            # Invalidate cached RoPE so it recomputes with
-                            # the new seqlen on next forward.
-                            cr = getattr(model, "cached_rope", None)
-                            if cr is not None:
-                                cr.cos_cache = None
-                                cr.sin_cache = None
-                                cr.seq_len = None
-                                cr.rope_image_info = None
-                        except Exception as _e2:
-                            logger.warning(
-                                f"  max_position_embeddings auto-bump skipped: {_e2}"
-                            )
-                except Exception as _e:
-                    logger.warning(f"  max_length auto-bump skipped: {_e}")
-
-                try:
-                    result = model.generate_image(
-                        prompt=instruction,
-                        image=temp_path,  # Single image path
-                        seed=seed,
-                        image_size=image_size,
-                        use_system_prompt=use_system_prompt_value,
-                        system_prompt=custom_system_prompt,
-                        bot_task=bot_task,
-                        infer_align_image_size=pass_align,
-                        max_new_tokens=max_new_tokens,
-                        verbose=verbose,
-                    )
-                finally:
-                    if _orig_max_length is not None:
-                        model.generation_config.max_length = _orig_max_length
-                    if _orig_max_pos is not None:
-                        try:
-                            model.config.max_position_embeddings = _orig_max_pos
-                        except Exception:
-                            pass
-                        # Drop stale RoPE cache after restore too
-                        cr = getattr(model, "cached_rope", None)
-                        if cr is not None:
-                            cr.cos_cache = None
-                            cr.sin_cache = None
-                            cr.seq_len = None
-                            cr.rope_image_info = None
-            finally:
-                if _orig_get_target_size is not None and _patched_reso_group is not None:
-                    _patched_reso_group.get_target_size = _orig_get_target_size
-                if _orig_build_gen_image_info is not None and _patched_image_processor is not None:
-                    _patched_image_processor.build_gen_image_info = _orig_build_gen_image_info
-                logger.info(
-                    f"  [trace summary] get_target_size called "
-                    f"{_trace_call_count['get_target_size']}x, "
-                    f"build_gen_image_info called "
-                    f"{_trace_call_count['build_gen_image_info']}x"
-                )
+            logger.info(f"  Resolution: {image_size}")
+            result = model.generate_image(
+                prompt=instruction,
+                image=temp_path,  # Single image path
+                seed=seed,
+                image_size=image_size,
+                use_system_prompt=use_system_prompt_value,
+                system_prompt=custom_system_prompt,
+                bot_task=bot_task,
+                infer_align_image_size=align_output_size and image_size == "auto",
+                max_new_tokens=max_new_tokens,
+                verbose=verbose,
+            )
             
             # Handle return value
             if isinstance(result, tuple) and len(result) == 2:
@@ -2986,13 +3115,6 @@ class HunyuanInstructImageEdit:
             # Convert PIL to tensor
             if samples and len(samples) > 0:
                 pil_image = samples[0]
-                try:
-                    logger.info(
-                        f"  [trace] generate_image returned PIL size "
-                        f"(w={pil_image.size[0]}, h={pil_image.size[1]})"
-                    )
-                except Exception:
-                    pass
                 image_tensor = pil_to_tensor(pil_image)
             else:
                 raise RuntimeError("No image generated")
@@ -3286,20 +3408,6 @@ class HunyuanInstructMultiFusion:
             
             # Aggressive VRAM cleanup before fusion - clears stale KV cache
             _aggressive_vram_cleanup(model, context="multi-fusion")
-
-            # Defensive: patch model.device to skip meta tensors (idempotent).
-            if SHARED_UTILS_AVAILABLE and patch_model_device_meta_safe:
-                try:
-                    patch_model_device_meta_safe(model)
-                except Exception:
-                    pass
-
-            # Defensive: strip accelerate hooks from VAE (idempotent).
-            if SHARED_UTILS_AVAILABLE and strip_accelerate_hooks_from_vae:
-                try:
-                    strip_accelerate_hooks_from_vae(model)
-                except Exception:
-                    pass
             
             logger.info(f"Starting multi-image fusion with bot_task='{bot_task}' "
                         f"(this may take several minutes for recaption modes)...")

--- a/tools/fix_hunyuan_accelerate_transformers.bat
+++ b/tools/fix_hunyuan_accelerate_transformers.bat
@@ -1,0 +1,87 @@
+﻿@echo off
+setlocal EnableExtensions
+chcp 65001 >nul
+title HunyuanImage 3 - Fix Accelerate and Transformers
+
+rem This BAT must be placed in the ComfyUI root folder:
+rem C:\ComfyUI\fix_hunyuan_python_versions.bat
+rem Expected embedded Python:
+rem C:\ComfyUI\python_embeded\python.exe
+
+set "ROOT=%~dp0"
+set "PYTHON=%ROOT%python_embeded\python.exe"
+set "BACKUP=%ROOT%packages_before_hunyuan_fix.txt"
+
+echo ============================================================
+echo HunyuanImage 3 dependency repair
+echo ============================================================
+echo.
+echo Required versions:
+echo   accelerate   1.14.0
+echo   transformers 4.57.6
+echo.
+
+if not exist "%PYTHON%" (
+    echo [ERROR] Embedded Python was not found:
+    echo         "%PYTHON%"
+    echo.
+    echo Put this BAT in the ComfyUI root folder, for example:
+    echo C:\ComfyUI\fix_hunyuan_python_versions.bat
+    goto :failed
+)
+
+echo [1/5] Saving the current package list...
+"%PYTHON%" -m pip freeze > "%BACKUP%"
+if errorlevel 1 (
+    echo [WARNING] Could not save the package list.
+) else (
+    echo       Saved to:
+    echo       "%BACKUP%"
+)
+echo.
+
+echo [2/5] Removing existing Accelerate and Transformers...
+"%PYTHON%" -m pip uninstall -y accelerate transformers
+if errorlevel 1 goto :failed
+echo.
+
+echo [3/5] Installing the tested versions...
+"%PYTHON%" -m pip install --no-cache-dir "accelerate==1.14.0" "transformers==4.57.6"
+if errorlevel 1 goto :failed
+echo.
+
+echo [4/5] Verifying imports and versions...
+"%PYTHON%" -c "import accelerate, transformers; print('accelerate:', accelerate.__version__); print('transformers:', transformers.__version__); assert accelerate.__version__ == '1.14.0'; assert transformers.__version__ == '4.57.6'; print('VERSION CHECK: OK')"
+if errorlevel 1 goto :failed
+echo.
+
+echo [5/5] Checking the main Hunyuan imports...
+"%PYTHON%" -c "from transformers import AutoModelForCausalLM; from accelerate import init_empty_weights; print('HUNYUAN IMPORT CHECK: OK')"
+if errorlevel 1 goto :failed
+echo.
+
+echo ============================================================
+echo SUCCESS
+echo ============================================================
+echo Installed:
+echo   accelerate   1.14.0
+echo   transformers 4.57.6
+echo.
+echo Completely close and restart ComfyUI before generating.
+echo Do not run Update All after this unless you are ready to
+echo restore these versions again.
+echo.
+pause
+exit /b 0
+
+:failed
+echo.
+echo ============================================================
+echo INSTALLATION FAILED
+echo ============================================================
+echo Review the messages above.
+echo The previous package list, if created, is here:
+echo "%BACKUP%"
+echo.
+pause
+exit /b 1

--- a/workflows/HunyuanImage3_Instruct_BF16_DiskOffload_ImageToImage.json
+++ b/workflows/HunyuanImage3_Instruct_BF16_DiskOffload_ImageToImage.json
@@ -1,0 +1,309 @@
+{
+  "last_node_id": 5,
+  "last_link_id": 4,
+  "nodes": [
+    {
+      "id": 1,
+      "type": "HunyuanInstructLoader",
+      "pos": [
+        20,
+        20
+      ],
+      "size": [
+        440,
+        410
+      ],
+      "flags": {},
+      "order": 0,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "model",
+          "type": "HUNYUAN_INSTRUCT_MODEL",
+          "links": [
+            1
+          ],
+          "slot_index": 0
+        }
+      ],
+      "title": "1. Full BF16 Loader — CUDA / CPU / Disk",
+      "properties": {
+        "Node name for S&R": "HunyuanInstructLoader"
+      },
+      "widgets_values": [
+        "HunyuanImage-3.0-Instruct",
+        false,
+        "sdpa",
+        "eager",
+        8.0,
+        0,
+        true,
+        "bfloat16",
+        true,
+        "",
+        32
+      ]
+    },
+    {
+      "id": 2,
+      "type": "LoadImage",
+      "pos": [
+        20,
+        500
+      ],
+      "size": [
+        330,
+        320
+      ],
+      "flags": {},
+      "order": 1,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": [
+            2
+          ],
+          "slot_index": 0,
+          "shape": 3
+        },
+        {
+          "name": "MASK",
+          "type": "MASK",
+          "links": null,
+          "slot_index": 1,
+          "shape": 3
+        }
+      ],
+      "title": "2. Select Input Image",
+      "properties": {
+        "Node name for S&R": "LoadImage"
+      },
+      "widgets_values": [
+        "input.png",
+        "image"
+      ]
+    },
+    {
+      "id": 3,
+      "type": "ImageScale",
+      "pos": [
+        410,
+        530
+      ],
+      "size": [
+        320,
+        140
+      ],
+      "flags": {},
+      "order": 2,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "image",
+          "type": "IMAGE",
+          "link": 2,
+          "slot_index": 0
+        }
+      ],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": [
+            3
+          ],
+          "slot_index": 0,
+          "shape": 3
+        }
+      ],
+      "title": "3. Scale Input to 512×512 for Lower Peak Memory",
+      "properties": {
+        "Node name for S&R": "ImageScale"
+      },
+      "widgets_values": [
+        "lanczos",
+        512,
+        512,
+        "center"
+      ]
+    },
+    {
+      "id": 4,
+      "type": "HunyuanInstructImageEdit",
+      "pos": [
+        800,
+        20
+      ],
+      "size": [
+        570,
+        650
+      ],
+      "flags": {},
+      "order": 3,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "model",
+          "type": "HUNYUAN_INSTRUCT_MODEL",
+          "link": 1,
+          "slot_index": 0
+        },
+        {
+          "name": "image",
+          "type": "IMAGE",
+          "link": 3,
+          "slot_index": 1
+        }
+      ],
+      "outputs": [
+        {
+          "name": "image",
+          "type": "IMAGE",
+          "links": [
+            4
+          ],
+          "slot_index": 0,
+          "shape": 3
+        },
+        {
+          "name": "cot_reasoning",
+          "type": "STRING",
+          "links": null,
+          "slot_index": 1,
+          "shape": 3
+        },
+        {
+          "name": "status",
+          "type": "STRING",
+          "links": null,
+          "slot_index": 2,
+          "shape": 3
+        }
+      ],
+      "title": "4. Image to Image — Direct Image Mode / 40 Steps",
+      "properties": {
+        "Node name for S&R": "HunyuanInstructImageEdit"
+      },
+      "widgets_values": [
+        "Change the background to a warm sunset scene. Preserve the subject, facial features, pose, clothing, composition, and every detail not explicitly mentioned.",
+        "image",
+        123456789,
+        "dynamic",
+        true,
+        "Auto (model predicts)",
+        40,
+        -1.0,
+        2.8,
+        2048,
+        0
+      ]
+    },
+    {
+      "id": 5,
+      "type": "SaveImage",
+      "pos": [
+        1430,
+        120
+      ],
+      "size": [
+        360,
+        430
+      ],
+      "flags": {},
+      "order": 4,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "link": 4,
+          "slot_index": 0
+        }
+      ],
+      "outputs": [],
+      "title": "5. Save Edited Image",
+      "properties": {
+        "Node name for S&R": "SaveImage"
+      },
+      "widgets_values": [
+        "HunyuanImage3_BF16_DiskOffload_I2I"
+      ]
+    }
+  ],
+  "links": [
+    [
+      1,
+      1,
+      0,
+      4,
+      0,
+      "HUNYUAN_INSTRUCT_MODEL"
+    ],
+    [
+      2,
+      2,
+      0,
+      3,
+      0,
+      "IMAGE"
+    ],
+    [
+      3,
+      3,
+      0,
+      4,
+      1,
+      "IMAGE"
+    ],
+    [
+      4,
+      4,
+      0,
+      5,
+      0,
+      "IMAGE"
+    ]
+  ],
+  "groups": [
+    {
+      "id": 1,
+      "title": "Experimental Full-BF16 Image to Image",
+      "bounding": [
+        -10,
+        -20,
+        1840,
+        900
+      ],
+      "color": "#3f789e",
+      "font_size": 24,
+      "flags": {}
+    }
+  ],
+  "config": {},
+  "extra": {
+    "ds": {
+      "scale": 0.72,
+      "offset": [
+        55,
+        75
+      ]
+    },
+    "info": {
+      "fork": "foxidermist/Comfy_HunyuanImage3",
+      "mode": "full BF16 CUDA/CPU/disk offload",
+      "settings": {
+        "vram_reserve_gb": 8,
+        "cpu_memory_limit_gb": 32,
+        "blocks_to_swap": 0,
+        "use_disk_offload": true,
+        "bot_task": "image",
+        "steps": 40
+      }
+    }
+  },
+  "version": 0.4
+}

--- a/workflows/HunyuanImage3_Instruct_BF16_DiskOffload_TextToImage.json
+++ b/workflows/HunyuanImage3_Instruct_BF16_DiskOffload_TextToImage.json
@@ -1,0 +1,202 @@
+{
+  "last_node_id": 3,
+  "last_link_id": 2,
+  "nodes": [
+    {
+      "id": 1,
+      "type": "HunyuanInstructLoader",
+      "pos": [
+        20,
+        20
+      ],
+      "size": [
+        440,
+        410
+      ],
+      "flags": {},
+      "order": 0,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "model",
+          "type": "HUNYUAN_INSTRUCT_MODEL",
+          "links": [
+            1
+          ],
+          "slot_index": 0
+        }
+      ],
+      "title": "1. Full BF16 Loader — CUDA / CPU / Disk",
+      "properties": {
+        "Node name for S&R": "HunyuanInstructLoader"
+      },
+      "widgets_values": [
+        "HunyuanImage-3.0-Instruct",
+        false,
+        "sdpa",
+        "eager",
+        8.0,
+        0,
+        true,
+        "bfloat16",
+        true,
+        "",
+        32
+      ]
+    },
+    {
+      "id": 2,
+      "type": "HunyuanInstructGenerate",
+      "pos": [
+        530,
+        20
+      ],
+      "size": [
+        560,
+        610
+      ],
+      "flags": {},
+      "order": 1,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "model",
+          "type": "HUNYUAN_INSTRUCT_MODEL",
+          "link": 1,
+          "slot_index": 0
+        }
+      ],
+      "outputs": [
+        {
+          "name": "image",
+          "type": "IMAGE",
+          "links": [
+            2
+          ],
+          "slot_index": 0,
+          "shape": 3
+        },
+        {
+          "name": "cot_reasoning",
+          "type": "STRING",
+          "links": null,
+          "slot_index": 1,
+          "shape": 3
+        },
+        {
+          "name": "status",
+          "type": "STRING",
+          "links": null,
+          "slot_index": 2,
+          "shape": 3
+        }
+      ],
+      "title": "2. Text to Image — Direct Image Mode / 40 Steps",
+      "properties": {
+        "Node name for S&R": "HunyuanInstructGenerate"
+      },
+      "widgets_values": [
+        "A cinematic photograph of a lone lighthouse on a stormy coast at blue hour, dramatic clouds, realistic ocean spray, detailed natural lighting",
+        "image",
+        "dynamic",
+        "1024x1024 (1:1 Square)",
+        123456789,
+        40,
+        -1.0,
+        2.8,
+        2048,
+        0,
+        "auto",
+        "auto"
+      ]
+    },
+    {
+      "id": 3,
+      "type": "SaveImage",
+      "pos": [
+        1160,
+        90
+      ],
+      "size": [
+        360,
+        430
+      ],
+      "flags": {},
+      "order": 2,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "link": 2,
+          "slot_index": 0
+        }
+      ],
+      "outputs": [],
+      "title": "3. Save Generated Image",
+      "properties": {
+        "Node name for S&R": "SaveImage"
+      },
+      "widgets_values": [
+        "HunyuanImage3_BF16_DiskOffload_T2I"
+      ]
+    }
+  ],
+  "links": [
+    [
+      1,
+      1,
+      0,
+      2,
+      0,
+      "HUNYUAN_INSTRUCT_MODEL"
+    ],
+    [
+      2,
+      2,
+      0,
+      3,
+      0,
+      "IMAGE"
+    ]
+  ],
+  "groups": [
+    {
+      "id": 1,
+      "title": "Experimental Full-BF16 Text to Image",
+      "bounding": [
+        -10,
+        -20,
+        1560,
+        700
+      ],
+      "color": "#3f789e",
+      "font_size": 24,
+      "flags": {}
+    }
+  ],
+  "config": {},
+  "extra": {
+    "ds": {
+      "scale": 0.78,
+      "offset": [
+        55,
+        75
+      ]
+    },
+    "info": {
+      "fork": "foxidermist/Comfy_HunyuanImage3",
+      "mode": "full BF16 CUDA/CPU/disk offload",
+      "settings": {
+        "vram_reserve_gb": 8,
+        "cpu_memory_limit_gb": 32,
+        "blocks_to_swap": 0,
+        "use_disk_offload": true,
+        "bot_task": "image",
+        "steps": 40
+      }
+    }
+  },
+  "version": 0.4
+}

--- a/workflows/README.md
+++ b/workflows/README.md
@@ -1,0 +1,99 @@
+# Example Workflows
+
+These workflows demonstrate the experimental full-BF16 CUDA/CPU/disk loading
+path in the `foxidermist/Comfy_HunyuanImage3` fork.
+
+## Files
+
+- `HunyuanImage3_Instruct_BF16_DiskOffload_TextToImage.json`
+- `HunyuanImage3_Instruct_BF16_DiskOffload_ImageToImage.json`
+
+Import either JSON by dragging it into the ComfyUI canvas or using
+**Workflow → Open**.
+
+## Saved Loader Settings
+
+| Setting | Value |
+|---|---|
+| `vram_reserve_gb` | `8` |
+| `cpu_memory_limit_gb` | `32` |
+| `blocks_to_swap` | `0` |
+| `use_disk_offload` | `true` |
+| `moe_drop_tokens` | `true` |
+| `vae_dtype` | `bfloat16` |
+
+The `disk_offload_dir` widget is intentionally saved as an empty string. The
+public loader interprets an empty value as its platform-specific default cache
+directory. Users can enter a different fast local SSD directory directly in
+the loader.
+
+On GPUs below 24 GiB, the loader may clamp the requested 8 GiB VRAM reserve to
+its low-memory value so that at least one indivisible model module can remain
+assigned to CUDA. This is expected and is reported in the console.
+
+## Saved Generation Settings
+
+| Setting | Value |
+|---|---|
+| `bot_task` | `image` |
+| `steps` | `40` |
+| `guidance_scale` | `-1` (model default) |
+| `flow_shift` | `2.8` |
+| `system_prompt` | `dynamic` |
+
+With `bot_task=image`, the dynamic system-prompt selection disables the
+recaption prompt and uses direct image generation/editing.
+
+Forty steps are intended as a full run, not a smoke test. Disk-backed
+generation can take well over an hour on a 12 GB GPU.
+
+## Model Selection
+
+The workflow stores the folder name:
+
+```text
+HunyuanImage-3.0-Instruct
+```
+
+If ComfyUI displays a location suffix such as:
+
+```text
+HunyuanImage-3.0-Instruct [Models]
+```
+
+select that entry manually in the loader after importing the workflow.
+
+## Text-to-Image Workflow
+
+The text-to-image example uses the model-native:
+
+```text
+1024x1024 (1:1 Square)
+```
+
+resolution. Full Instruct uses CFG batch size 2, so this can exceed the memory
+available on some 12 GB GPUs. Test with fewer steps first when validating a new
+machine. Step count changes runtime, not the main resolution-dependent memory
+peak.
+
+## Image-to-Image Workflow
+
+The input image is scaled to `512×512` before editing to reduce peak memory.
+The edit node uses `Auto (model predicts)` with `align_output_size=true`, so the
+output is aligned to the scaled input where supported.
+
+Remove or modify the `ImageScale` node when using larger hardware.
+
+## Expected Loader Log
+
+A working disk-backed load should include:
+
+```text
+Model distributed across: 0, cpu, disk
+SSD disk offload active: ... modules mapped to disk
+```
+
+The auxiliary offload directory may remain empty when Accelerate reads tensors
+directly from the original sharded safetensors.
+
+See the repository-level `LOW_MEMORY_BF16.md` for setup and troubleshooting.


### PR DESCRIPTION
## Summary

Adds an experimental low-memory loading path for the full
HunyuanImage-3.0-Instruct BF16 checkpoint.

## Main changes

- CUDA/CPU/disk device mapping
- Configurable CPU memory budget
- Portable disk-offload directory
- Low-VRAM GPU budget handling
- Missing `config.model_version` compatibility fix
- Image-processor method compatibility alias
- SigLIP2 positional-embedding offload fix
- MultiheadAttention `out_proj` offload-hook fix
- RAM, virtual-memory, disk, and device-map diagnostics
- Text-to-image and image-to-image example workflows
- Detailed setup and troubleshooting documentation

## Tested environment

- Windows
- NVIDIA RTX 5070, 12 GB VRAM
- 64 GB system RAM
- 96 GB Windows pagefile
- PyTorch 2.13.0+cu130
- Transformers 4.57.6
- Accelerate 1.14.0
- Full BF16 HunyuanImage-3.0-Instruct checkpoint

A complete image-edit generation was successfully produced with disk-backed
execution.

## Tested workflow settings

- `vram_reserve_gb`: `8`
- `cpu_memory_limit_gb`: `32`
- `blocks_to_swap`: `0`
- `use_disk_offload`: `true`
- `bot_task`: `image`
- `steps`: `40`

## Scope

The changes affect model loading, device placement, compatibility, diagnostics,
documentation, and example workflows. Existing quantized and block-swap paths
are otherwise preserved.